### PR TITLE
Implement revised confirm dialogues #82

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -23,19 +23,6 @@
     </div>
   </div>
 
-  <!--Confirm messages-->
-  <div id="confirm-container" class="hidden">
-    <section id="confirm">
-      <h2 id="confirm-title">
-        <i class="fa fa-exclamation-triangle"></i> Confirm</h2>
-      <p id="confirm-text"></p>
-      <div id="confirm-button-container">
-        <button id="btn-cancel">Cancel</button>
-        <button id="btn-OK">OK</button>
-      </div>
-    </section>
-  </div>
-
   <main>
     <section id="main-area">
       <!--Capture Window-->

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -58,51 +58,6 @@
   font-size: 0.95em;
 }
 
-/* ========== CONFIRM BOXES ========== */
-
-#confirm-container {
-  position: absolute;
-  height: 100vh;
-  width: 100vw;
-  background-color: rgba(23, 23, 23, 0.5);
-  z-index: 4;
-  text-align: center;
-}
-
-#confirm-container.hidden { display: none; }
-
-#confirm {
-  position: relative;
-  top: calc(50vh - 10em);
-  display: inline-block;
-  width: 20em;
-  background-color: #000;
-  padding: 0 1em 1em 1em;
-  border: 1px solid #D9D9D9;
-}
-
-#confirm-title {
-  font-size: 1.2em;
-  color: rgb(224, 224, 100);
-}
-
-#confirm-text { text-align: left; }
-
-#confirm-button-container { float: right; }
-
-#confirm button {
-  float: left;
-  margin-left: 1em;
-  width: 6em;
-}
-
-#confirm button:hover { opacity: 0.9; }
-
-#confirm button:active { opacity: 0.7; }
-
-/*Confirm buttons are typically the other way round in Win32*/
-.platform-win #confirm button { float: right; }
-
 /* ========== SIDEBAR ============== */
 
 #currentDirectoryName {

--- a/app/css/common.css
+++ b/app/css/common.css
@@ -10,6 +10,7 @@
    4. Sidebar
    5. Footer
    6. Scrollbars
+   7. Alerts
 */
 
 /* 1. Global
@@ -195,3 +196,9 @@ footer li:not(.no-pipe)::after {
 ::-webkit-scrollbar-thumb:hover { background-color: #5C5858; }
 
 ::-webkit-scrollbar-thumb:active { background-color: #827E7E; }
+
+/* 7. Alerts
+   -------------------------------- */
+
+/* Fix blue outline around SweetAlert modals */
+.swal-overlay { outline: none; }

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -82,6 +82,7 @@ var streaming = false,
   notification = require("./js/notification"),
   saveDirectory = require("./js/savedirectory"),
   menubar = require("./js/menubar"),
+  swal = require("./lib/sweetalert"),
 
   // Sidebar
   dirChooseDialog = document.querySelector("#chooseDirectory"),

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -814,10 +814,10 @@ function saveFrame(id) {
 function confirmSet(swalArgs) {
   "use strict";
   // Set default SweetAlert argument values
-  swalArgs.title = ("title" in swalArgs) ? swalArgs.title : "Confirm";
-  swalArgs.text = ("text" in swalArgs) ? swalArgs.text : "Are you sure?";
-  swalArgs.icon = ("icon" in swalArgs) ? swalArgs.icon : "warning";
-  swalArgs.buttons = ("buttons" in swalArgs) ? swalArgs.buttons : true;
+  swalArgs.title = swalArgs.title ? swalArgs.title : "Confirm";
+  swalArgs.text = swalArgs.text ? swalArgs.text : "Are you sure?";
+  swalArgs.icon = swalArgs.icon ? swalArgs.icon : "warning";
+  swalArgs.buttons = swalArgs.button ? swalArgs.buttons : true;
 
   // Pause main shortcuts and menubar items
   shortcuts.remove("main");

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -818,6 +818,7 @@ function saveFrame(id) {
  *                    Resolves true if confirm was selected and null if the alert was dismissed.
  */
 function confirmSet(swalArgs) {
+  "use strict";
   // Set default SweetAlert argument values
   swalArgs.title = ("title" in swalArgs) ? swalArgs.title : "Confirm";
   swalArgs.text = ("text" in swalArgs) ? swalArgs.text : "Are you sure?";

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -125,7 +125,12 @@ function openAbout() {
  */
 win.on("close", function () {
   "use strict";
-  confirmSet(closeAnimator, "", "Are you sure you want to exit Boats Animator?");
+  confirmSet({text: "Are you sure you want to exit Boats Animator?"})
+  .then((response) => {
+    if (response) {
+      closeAnimator();
+    }
+  });
 });
 
 function closeAnimator() {
@@ -497,7 +502,13 @@ function undoFrame() {
   "use strict";
   // Make sure there is a frame to delete
   if (totalFrames > 0) {
-    confirmSet(deleteFrame, totalFrames, "Are you sure you want to delete the last frame captured?");
+    // Display warning alert to confirm deletion
+    confirmSet({text: "Are you sure you want to delete the last frame captured?"})
+    .then((response) => {
+      if (response) {
+        deleteFrame(totalFrames);
+      }
+    });
   } else {
     notification.error("There is no previous frame to undo!");
   }
@@ -801,59 +812,94 @@ function saveFrame(id) {
 }
 
 /**
+ * Creates a dialogue box
+ * @param {Object} swalArgs The SweetAlert arguments to use.
+ * @returns {Promise} Returns a Promise with the outcome of the dialogue.
+ *                    Resolves true if confirm was selected and null if the alert was dismissed.
+ */
+function confirmSet(swalArgs) {
+  // Set default SweetAlert argument values
+  swalArgs.title = ("title" in swalArgs) ? swalArgs.title : "Confirm";
+  swalArgs.text = ("text" in swalArgs) ? swalArgs.text : "Are you sure?";
+  swalArgs.icon = ("icon" in swalArgs) ? swalArgs.icon : "warning";
+  swalArgs.buttons = ("buttons" in swalArgs) ? swalArgs.buttons : true;
+  swalArgs.dangerMode = ("dangerMode" in swalArgs) ? dangerMode.buttons : true;
+
+  // Pause main shortcuts and menubar items
+  shortcuts.remove("main");
+  shortcuts.add("confirm");
+  menubar.toggleItems();
+
+  return new Promise(function(resolve, reject) {
+    // Create a SweetAlert dialogue with the selected arguments
+    swal(swalArgs)
+    .then((response) => {
+      // Resume main shortcuts and menubar items
+      shortcuts.remove("confirm");
+      shortcuts.add("main");
+      menubar.toggleItems();
+
+      // Resolve the promise
+      resolve(response);
+    });
+  });
+}
+
+/**
  * Confirm the action to be performed.
  *
  * @param {Function} callback The function to run on "OK" being pressed.
  * @param {*} args Arguments of function to run.
  * @param {String} msg Message to display in confirm dialogue.
  */
-function confirmSet(callback, args, msg) {
-  "use strict";
-  confirmText.innerHTML = msg;
-  confirmContainer.classList.remove("hidden");
-  btnConfirmOK.focus();
+// function confirmSet(callback, args, msg) {
+//   "use strict";
+  
+//   confirmText.innerHTML = msg;
+//   confirmContainer.classList.remove("hidden");
+//   btnConfirmOK.focus();
 
-  shortcuts.remove("main");
-  shortcuts.add("confirm");
+//   shortcuts.remove("main");
+//   shortcuts.add("confirm");
 
-  // Disable menubar items
-  menubar.toggleItems();
+//   // Disable menubar items
+//   menubar.toggleItems();
 
-  function _ok() {
-    callback(args);
-    _confirmSelect();
-  }
+//   function _ok() {
+//     callback(args);
+//     _confirmSelect();
+//   }
 
-  function _cancel() {
-    _confirmSelect();
-  }
+//   function _cancel() {
+//     _confirmSelect();
+//   }
 
-  function _confirmSelect() {
-    confirmContainer.classList.add("hidden");
+//   function _confirmSelect() {
+//     confirmContainer.classList.add("hidden");
 
-    btnConfirmOK.removeEventListener("click", _ok);
-    btnConfirmCancel.removeEventListener("click", _cancel);
+//     btnConfirmOK.removeEventListener("click", _ok);
+//     btnConfirmCancel.removeEventListener("click", _cancel);
 
-    btnConfirmOK.removeEventListener("blur", _focusCancel);
-    btnConfirmCancel.removeEventListener("blur", _focusOK);
+//     btnConfirmOK.removeEventListener("blur", _focusCancel);
+//     btnConfirmCancel.removeEventListener("blur", _focusOK);
 
-    shortcuts.remove("confirm");
-    shortcuts.add("main");
-    menubar.toggleItems();
-  }
+//     shortcuts.remove("confirm");
+//     shortcuts.add("main");
+//     menubar.toggleItems();
+//   }
 
-  // Respond to button clicks
-  btnConfirmOK.addEventListener("click", _ok);
-  btnConfirmCancel.addEventListener("click", _cancel);
+//   // Respond to button clicks
+//   btnConfirmOK.addEventListener("click", _ok);
+//   btnConfirmCancel.addEventListener("click", _cancel);
 
-  function _focusOK() {
-    btnConfirmOK.focus();
-  }
+//   function _focusOK() {
+//     btnConfirmOK.focus();
+//   }
 
-  function _focusCancel() {
-    btnConfirmCancel.focus();
-  }
+//   function _focusCancel() {
+//     btnConfirmCancel.focus();
+//   }
 
-  btnConfirmOK.addEventListener("blur", _focusCancel);
-  btnConfirmCancel.addEventListener("blur", _focusOK);
-}
+//   btnConfirmOK.addEventListener("blur", _focusCancel);
+//   btnConfirmCancel.addEventListener("blur", _focusOK);
+// }

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -70,12 +70,6 @@ var streaming = false,
   frameReelTable = document.querySelector("#area-frame-reel table"),
   liveViewframeNo = document.querySelector("#live-view-frame-no"),
 
-  // Confirm messages
-  confirmContainer = document.querySelector("#confirm-container"),
-  confirmText = document.querySelector("#confirm-text"),
-  btnConfirmOK = document.querySelector("#confirm-container #btn-OK"),
-  btnConfirmCancel = document.querySelector("#confirm-container #btn-cancel"),
-
   // Node modules
   file = require("./js/file"),
   shortcuts = require("./js/shortcuts"),
@@ -824,7 +818,6 @@ function confirmSet(swalArgs) {
   swalArgs.text = ("text" in swalArgs) ? swalArgs.text : "Are you sure?";
   swalArgs.icon = ("icon" in swalArgs) ? swalArgs.icon : "warning";
   swalArgs.buttons = ("buttons" in swalArgs) ? swalArgs.buttons : true;
-  swalArgs.dangerMode = ("dangerMode" in swalArgs) ? dangerMode.buttons : true;
 
   // Pause main shortcuts and menubar items
   shortcuts.remove("main");
@@ -845,62 +838,3 @@ function confirmSet(swalArgs) {
     });
   });
 }
-
-/**
- * Confirm the action to be performed.
- *
- * @param {Function} callback The function to run on "OK" being pressed.
- * @param {*} args Arguments of function to run.
- * @param {String} msg Message to display in confirm dialogue.
- */
-// function confirmSet(callback, args, msg) {
-//   "use strict";
-  
-//   confirmText.innerHTML = msg;
-//   confirmContainer.classList.remove("hidden");
-//   btnConfirmOK.focus();
-
-//   shortcuts.remove("main");
-//   shortcuts.add("confirm");
-
-//   // Disable menubar items
-//   menubar.toggleItems();
-
-//   function _ok() {
-//     callback(args);
-//     _confirmSelect();
-//   }
-
-//   function _cancel() {
-//     _confirmSelect();
-//   }
-
-//   function _confirmSelect() {
-//     confirmContainer.classList.add("hidden");
-
-//     btnConfirmOK.removeEventListener("click", _ok);
-//     btnConfirmCancel.removeEventListener("click", _cancel);
-
-//     btnConfirmOK.removeEventListener("blur", _focusCancel);
-//     btnConfirmCancel.removeEventListener("blur", _focusOK);
-
-//     shortcuts.remove("confirm");
-//     shortcuts.add("main");
-//     menubar.toggleItems();
-//   }
-
-//   // Respond to button clicks
-//   btnConfirmOK.addEventListener("click", _ok);
-//   btnConfirmCancel.addEventListener("click", _cancel);
-
-//   function _focusOK() {
-//     btnConfirmOK.focus();
-//   }
-
-//   function _focusCancel() {
-//     btnConfirmCancel.focus();
-//   }
-
-//   btnConfirmOK.addEventListener("blur", _focusCancel);
-//   btnConfirmCancel.addEventListener("blur", _focusOK);
-// }

--- a/app/js/menubar.js
+++ b/app/js/menubar.js
@@ -39,7 +39,14 @@ module.exports = {};
         {
           label: "Main Menu",
           click: function () {
-            confirmSet(openIndex, "", "Returning to the menu will cause any unsaved work to be lost!");
+            shortcuts.pause();
+            confirmSet({text: "Returning to the menu will cause any unsaved work to be lost!"})
+            .then((response) => {
+              if (response) {
+                openIndex();
+              }
+              shortcuts.resume();
+            });
           },
           key: "w",
           modifiers: controlKey,
@@ -48,7 +55,14 @@ module.exports = {};
         {
           label: "Exit",
           click: function () {
-            confirmSet(closeAnimator, "", "Are you sure you to exit Boats Animator?");
+            shortcuts.pause();
+            confirmSet({text: "Are you sure you want to exit Boats Animator?"})
+            .then((response) => {
+              if (response) {
+                closeAnimator();
+              }
+              shortcuts.resume();
+            });
           },
           key: "q",
           modifiers: controlKey,

--- a/app/js/menubar.js
+++ b/app/js/menubar.js
@@ -39,13 +39,11 @@ module.exports = {};
         {
           label: "Main Menu",
           click: function () {
-            shortcuts.pause();
             confirmSet({text: "Returning to the menu will cause any unsaved work to be lost!"})
             .then((response) => {
               if (response) {
                 openIndex();
               }
-              shortcuts.resume();
             });
           },
           key: "w",
@@ -55,13 +53,11 @@ module.exports = {};
         {
           label: "Exit",
           click: function () {
-            shortcuts.pause();
             confirmSet({text: "Are you sure you want to exit Boats Animator?"})
             .then((response) => {
               if (response) {
                 closeAnimator();
               }
-              shortcuts.resume();
             });
           },
           key: "q",

--- a/app/js/shortcuts.js
+++ b/app/js/shortcuts.js
@@ -47,6 +47,10 @@ module.exports = {};
         // Features in confirm prompts.
         confirm: {
           enter: function() {
+            // Confirm messages
+            var btnConfirmOK = document.querySelector(".swal-button--confirm");
+            var btnConfirmCancel = document.querySelector(".swal-button--cancel");
+
             if (document.activeElement === btnConfirmOK) {
               btnConfirmOK.click();
             } else if (document.activeElement === btnConfirmCancel) {
@@ -54,6 +58,7 @@ module.exports = {};
             }
           },
           cancel: function() {
+            var btnConfirmCancel = document.querySelector(".swal-button--cancel");
             btnConfirmCancel.click();
           }
         }

--- a/install.js
+++ b/install.js
@@ -21,4 +21,8 @@ fs.exists("app/lib", function(exists) {
   fs.copy("node_modules/mousetrap/plugins/pause/mousetrap-pause.min.js", "app/lib/mousetrap-pause.js", { replace: true }, function (err) {
     console.log(err ? err : "Copied mousetrap-pause.min.js to 'app/lib/mousetrap-pause.js'");
   });
+  // SweetAlert
+  fs.copy("node_modules/sweetalert/dist/sweetalert.min.js", "app/lib/sweetalert.js", { replace: true }, function (err) {
+    console.log(err ? err : "Copied mousetrap-pause.min.js to 'app/lib/mousetrap-pause.js'");
+  });
 });

--- a/install.js
+++ b/install.js
@@ -23,6 +23,6 @@ fs.exists("app/lib", function(exists) {
   });
   // SweetAlert
   fs.copy("node_modules/sweetalert/dist/sweetalert.min.js", "app/lib/sweetalert.js", { replace: true }, function (err) {
-    console.log(err ? err : "Copied mousetrap-pause.min.js to 'app/lib/mousetrap-pause.js'");
+    console.log(err ? err : "Copied sweetalert.min.js to 'app/lib/sweetalert.js'");
   });
 });

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "fs.extra": "^1.3.2",
     "mkdirp": "^0.5.1",
     "mousetrap": "^1.6.2",
-    "nwjs-builder": "^1.12.0"
+    "nwjs-builder": "^1.12.0",
+    "sweetalert": "^2.1.2"
   },
   "devDependencies": {
     "nw-dev": "^3.0.1"


### PR DESCRIPTION
This PR implements revised confirm dialogues using the SweetAlert library rather than the previous custom solution. While the old dialogues matched the general theme of BA better, I have chosen to leave the new ones as is, because they provide a greater contrast with the background.

The new dialogues return a promise and are configurable with all of the library's features, so are much more customisable than before.

## Before:

![screenshot 100](https://user-images.githubusercontent.com/8095888/50446527-32062880-090d-11e9-8e42-f60107060f42.png)

## After:

![screenshot 101](https://user-images.githubusercontent.com/8095888/50446531-33cfec00-090d-11e9-9303-90860590867a.png)
