### PR TITLE
Store Camera.list in local storage #227

### DIFF
--- a/app/js/camera.js
+++ b/app/js/camera.js
@@ -227,7 +227,6 @@ module.exports = {};
       if (!(source.deviceId in Camera.list)) {
         const cam = new Camera(source.deviceId, cameraName);
         Camera.list[source.deviceId] = cam;
-        notification.success(`Detected ${cam.name}`);
         // Update localStorage list
         Camera.setStoredCams();
       }


### PR DESCRIPTION
This stores found cameras and resolutions to localStorage. This means that the program doesn't need to calculate which resolutions a camera supports on every single launch.