### PR TITLE
Bump NW.js to v0.35.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If you're working on an improvement to Boats Animator it is usually good practis
 
 ## Coding conventions
 The following conventions should be observed in Boats Animator's code:
-* HTML5, CSS3 and ES6 JavaScript that is supported by Chromium 62 may be used.
+* HTML5, CSS3 and ES6 JavaScript that is supported by Chromium 71 may be used.
 * Features with the `Webkit` prefix may be used if there is no standardised method available.
 * Code should use **2 space indentation** ([currently a WIP](https://github.com/charlielee/boats-animator/issues/140)).
 * Trailing white space should be avoided.

--- a/app/js/camera-resolutions.js
+++ b/app/js/camera-resolutions.js
@@ -60,7 +60,7 @@ module.exports = {};
           curStream = stream;
           videoStream.width = candidate.width;
           videoStream.height = candidate.height;
-          videoStream.src = window.URL.createObjectURL(stream);
+          videoStream.srcObject = stream;
           videoStream.play();
         }
 

--- a/app/js/camera.js
+++ b/app/js/camera.js
@@ -79,7 +79,7 @@ module.exports = {};
    */
   Camera.display = function (feed, output) {
     feed.addEventListener("canplay", function () {
-      output.src = feed.src;
+      output.srcObject = feed.srcObject;
     });
   }
 
@@ -161,7 +161,6 @@ module.exports = {};
       Camera.display(feed, document.querySelector("#preview"));
     } catch (err) {
       notification.error(`${curCam.name} could not be loaded!`);
-      document.querySelector("#preview").src = "#";
     } finally {
       previewArea.curWindow.display();
     }
@@ -300,7 +299,7 @@ module.exports = {};
     // Update resolution in status bar
     statusBarCurRes.innerText = curRes;
 
-    videoCapture.src = window.URL.createObjectURL(mediaStream);
+    videoCapture.srcObject = mediaStream;
     videoCapture.play();
 
     curStream = mediaStream;

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -21,10 +21,10 @@
       height: 715,
       min_width: 590,
       min_height: 500,
-      focus: true,
-      icon: "icons/icon.png",
+      icon: "icons/icon.png"
+    }, function(newWin) {
+      win.close();
     });
-    win.close();
   }
 
   // Open the animator

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -93,10 +93,10 @@ function openIndex() {
     height: 450,
     min_width: 730,
     min_height: 450,
-    focus: true,
     icon: "icons/icon.png"
+  }, function(newWin) {
+    win.close(true);
   });
-  win.close(true);
 }
 
 /**
@@ -108,7 +108,6 @@ function openAbout() {
     position: "center",
     width: 650,
     height: 300,
-    focus: true,
     icon: "icons/icon.png",
     resizable: false,
   });

--- a/build.js
+++ b/build.js
@@ -47,7 +47,7 @@ var manifest = require('./package.json'),
     nwjsBuilder = require("nwjs-builder"),
     options = {
       platforms: cmdOptions.platforms,
-      version: "0.26.6",
+      version: "0.35.4",
       outputDir: "bin/Boats-Animator",
       outputName: "Boats-Animator-{version}-{target}",
       outputFormat: "DIR",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "postinstall": "node install",
-    "start": "nwb nwbuild -v 0.26.6-sdk -r .",
+    "start": "nwb nwbuild -v 0.35.4-sdk -r .",
     "test": "node build -n",
     "build": "node build",
     "build-extras": "node build -e exe"


### PR DESCRIPTION
This PR moves Boats Animator from NW.js 0.26 to 0.35 (Chromium 62 to 71). #222 

Initially, when I bumped the version, loading the animator window from the launcher resulted in a blank screen, any of version of NW.js from 0.27 onwards has this issue. This has been fixed by moving `win.close()` of the launcher into a callback. I have no idea why this broke.

I have also removed `createObjectURL` from media stream elements as this is no longer possible. https://developers.google.com/web/updates/2018/10/chrome-71-deps-rems#remove_urlcreateobjecturl_from_mediastream

I can't see any other obvious issues, so this PR should be good to go!