### PR TITLE
Capture improvements

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -775,27 +775,6 @@ function _displaySaveDirectory(dir) {
 }
 
 /**
-* Convert frames from base64 to png
-*
-* @author Stack Overflow http://stackoverflow.com/questions/20267939
-* @author Julian Lannigan http://stackoverflow.com/users/1777444
-* @license cc by-sa 3.0
-*/
-function decodeBase64Image(dataString) {
-  "use strict";
-  var matches = dataString.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/),
-    response = {};
-
-  if (matches.length !== 3) {
-    return new Error("Invalid input string");
-  }
-
-  response.type = matches[1];
-  response.data = new Buffer.from(matches[2], "base64");
-  return response;
-}
-
-/**
  * Save the captured frame to the hard drive.
  *
  * @param {Number} id - The frame ID to save.

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -652,11 +652,13 @@ function _displayFrame(id) {
 
     // Preview selected frame ID
     _addFrameReelSelection(id);
-    curPlayFrame = id - 1;
     context.drawImage(capturedFrames[id - 1], 0, 0, preview.videoWidth, preview.videoHeight);
     _updateStatusBarCurFrame(id);
     _frameReelScroll();
   }
+
+  // Set the current play frame
+  curPlayFrame = id - 1;
 }
 
 /**
@@ -698,7 +700,10 @@ function _videoPlay() {
 function previewCapturedFrames() {
   "use strict";
   // Display playback window
-  switchMode(PlaybackWindow);
+  if (PreviewArea.curWindow === CaptureWindow) {
+    switchMode(PlaybackWindow);
+    curPlayFrame = 0;
+  }
 
   // Reset canvas to first frame if playing from start
   if (curPlayFrame == 0) {

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -566,6 +566,9 @@ function _captureFrame() {
 
     // Convert the frame to a PNG
     playback.toBlob(function(blob) {
+      // Play a camera sound
+      audio(captureAudio);
+
       var frame = new Image();
       var url = URL.createObjectURL(blob);
       frame.src = url;
@@ -581,10 +584,7 @@ function _captureFrame() {
 
       // Scroll the frame reel to the end
       frameReelArea.scrollLeft = frameReelArea.scrollWidth;
-
-      // Play a camera sound
-      audio(captureAudio);
-    });
+    }, "image/png");
   }
 }
 
@@ -783,6 +783,7 @@ function _displaySaveDirectory(dir) {
  * Save the captured frame to the hard drive.
  *
  * @param {Number} id - The frame ID to save.
+ * @param {Blob} blob - The Blob object containing image data to save.
  */
 function saveFrame(id, blob) {
   "use strict";

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -787,7 +787,7 @@ function decodeBase64Image(dataString) {
   }
 
   response.type = matches[1];
-  response.data = new Buffer(matches[2], "base64");
+  response.data = new Buffer.from(matches[2], "base64");
   return response;
 }
 


### PR DESCRIPTION
This PR focuses on improving the methods used in frame capture to be much more optimal. Including:
* Using blob instead of base64 (`canvas.toBlob` instead of `canvas.toDataUrl`)
* Using `Buffer.from()` instead of `Buffer()`
* I have also had to port a few of the playback fixes made in the `modules` branch as they seemed to start occurring here too.

This should hopefully improve the capture delay issues mentioned here:
https://www.bricksinmotion.com/forums/post/380380/#p380380

There is still a bit of delay in frames appearing on the frame reel (as they need to be written to disk) however anecdotally capture performance seems to be far better.

_(note this doesn't modularise frame capture, that will be coming separately later!)_