### PR TITLE
Refactor confirm take to use Promise.all and fix delete any frame bug

### DIFF
--- a/app/common/File/File.js
+++ b/app/common/File/File.js
@@ -133,6 +133,25 @@ module.exports = {};
   }
 
   /**
+   * Rename a file on the hard drive.
+   *
+   * @param {String} oldName - Absolute path to the file to the current file.
+   * @param {String} newName - Absolute path to the file to the new file. 
+   */
+  function renameFilePromise(oldName, newName) {
+    return new Promise((resolve, reject) => {
+      fs.rename(oldName, newName, function(err) {
+        if (err) {
+          reject(err);
+        } else {
+          console.log(`Successfully renamed ${oldName} to ${newName}`);
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
    * Write a file to the hard drive.
    *
    * @param {String} file - Absolute path to the file to be saved.
@@ -162,5 +181,6 @@ module.exports = {};
   module.exports.read = readFile;
   module.exports.write = writeFile;
   module.exports.rename = renameFile;
+  module.exports.renamePromise = renameFilePromise;
   module.exports.delete = deleteFile;
 }());

--- a/app/main/Take/Take.js
+++ b/app/main/Take/Take.js
@@ -37,6 +37,8 @@
       this.frameReel = new FrameReel();
       // The onion skin for the take
       this.onionSkin = new OnionSkin();
+      // Id of the last exported frame
+      this.exportFrameId = 0;
     }
 
     /**
@@ -77,7 +79,7 @@
           self.frameReel.setFrameThumbnail(id, self.capturedFrames[id - 1].src);
 
           self._updateOnionSkin();
-          self._exportFrame(id, blob);
+          self._exportFrame(blob);
           resolve(`Captured frame: ${id}`);
         });
       });
@@ -134,6 +136,8 @@
 
       // Rename all of the files
       Promise.all(promisesList).then(() => {
+        // Reset last export frame id
+        self.exportFrameId = self.getTotalFrames();
         Notification.success("Confirm take successfully completed");
       }).catch((err) => {
         console.error(err);
@@ -169,11 +173,12 @@
 
     /**
      * Writes a frame to the disk and stores the path.
-     * @param {Integer} id The id of the frame to export
      * @param {Blob} blob The Blob object containing image data to save.
      */
-    _exportFrame(id, blob) {
-      var fileName = "";
+    _exportFrame(blob) {
+      this.exportFrameId++;
+      let id = this.exportFrameId;
+      let fileName = "";
 
       // 1K+ frames have been captured
       if (id >= 1000) {


### PR DESCRIPTION
This implements #250. I also fixed a terrible bug with the "delete any frame" feature. After using it, to delete a frame, the next frame captured would overwrite the last frame captured. 0.9.2 will be immediately released after this.