### PR TITLE
Remember size and position of window 

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -21,6 +21,7 @@
       height: 715,
       min_width: 590,
       min_height: 500,
+      id: "animatorWindow",
       icon: "icons/icon.png"
     }, function(newWin) {
       win.close();

--- a/app/ui/WindowManager/WindowManager.js
+++ b/app/ui/WindowManager/WindowManager.js
@@ -7,11 +7,7 @@
 
   class WindowManager {
     static setListeners() {
-      // Maximise window
-
-      // This call seems to bypass the id property in the window.open() options 
-      //win.maximize();
-
+      
       /**
        * Confirm prompt when animator is closed.
        */

--- a/app/ui/WindowManager/WindowManager.js
+++ b/app/ui/WindowManager/WindowManager.js
@@ -8,7 +8,9 @@
   class WindowManager {
     static setListeners() {
       // Maximise window
-      win.maximize();
+
+      // This call seems to bypass the id property in the window.open() options 
+      //win.maximize();
 
       /**
        * Confirm prompt when animator is closed.


### PR DESCRIPTION
This PR implements issue #219 

(Please ignore the terrible brach name. I was supposed to write issue-219-rem.size 😂) 

Using a similar approach, the index.html page (welcome window) could be added an id property to remember its size as well. (Although I think we should leave it like that, since we wouldn't want it to occupy the entire screen after reopening - even if the user scales it to do so). Hopefully that makes sense. 
