### PR TITLE
Add unique id to each take

### DIFF
--- a/app/main/ExportVideo/ExportVideo.js
+++ b/app/main/ExportVideo/ExportVideo.js
@@ -46,7 +46,7 @@
         <br>
         <select id="presetSelect">
           <option value="veryslow">Very slow</option>
-          <option value="medium">Medium</option>
+          <option value="medium" selected>Medium</option>
           <option value="veryfast">Very fast</option>
         </select>
 
@@ -210,8 +210,10 @@
      * @param {Number} startFrameNo The frame to begin rendering from (default: 0 - ie the start).
      */
     static generateFfmpegArguments(exportPath, frameDirectory, frameRate, preset = "medium", startFrameNo = 0) {
-      let endFrameNo = global.projectInst.currentTake.getTotalFrames();
-      let framePath = path.join(frameDirectory, "frame_%04d.png");
+      let currentTake = global.projectInst.currentTake;
+      let endFrameNo = currentTake.getTotalFrames();
+      let frameFileName = currentTake.buildFileName("%05d");
+      let framePath = path.join(frameDirectory, frameFileName);
 
       // TODO should the default startFrameNo be 0 or 1?
 

--- a/app/main/Project/Project.js
+++ b/app/main/Project/Project.js
@@ -31,7 +31,6 @@
      * @param {String} title The project's title
      */
     constructor(title) {
-      // Initialise the project
       this.frameRate = new FrameRate(15);
       this.currentMode = null;
       this.currentTake = null;
@@ -42,6 +41,8 @@
       this.streaming = false;
       this.title = title;
       this.takes = [];
+
+      console.log(`Created new project: ${this.title}`);
     }
 
     /**

--- a/app/main/SaveDirectory/SaveDirectory.js
+++ b/app/main/SaveDirectory/SaveDirectory.js
@@ -61,21 +61,6 @@
         this.saveDirLocation = newLocation;
         SaveDirectory._setLocalStorageDir(newLocation);
         SaveDirectory.displaySaveDirectory(newLocation);
-
-        // Check the new directory is empty
-        SaveDirectory.checkDirHasNoFrames(newLocation, function(hasFrames) {
-          if (hasFrames) {
-            ConfirmDialog.confirmSet({
-              text: "The current save directory already contains captured frames! Please switch save directory or they will be overwritten.",
-              buttons: ["Continue", "Change save directory"]
-            })
-            .then((response) => {
-              if (response) {
-                SaveDirectory.openDirChooseDialog();
-              }
-            });
-          }
-        });
       }
     }
 
@@ -121,27 +106,6 @@
      */
     static checkDir(dir) {
       return fs.existsSync(dir);
-    }
-
-    /**
-     * Check if the app save directory has any frames, to prevent them being overwritten.
-     * TODO - this method will be unnecessary once Projects are fully implemented.
-     * 
-     * @param {String} dir - The directory to check.
-     * @callback Returns true if frames found in the selected directory, otherwise false.
-     */
-    static checkDirHasNoFrames(dir, cb) {
-      var files = fs.readdirSync(dir);
-
-      // Filter files that are frames
-      var regex = /\b(frame)(.)+(.png)\b/i;
-      var filteredFiles = files.filter((fileName) => { return regex.test(fileName) });
-
-      if (filteredFiles.length > 0) {
-        cb(true);
-      } else {
-        cb(false);
-      }
     }
 
     /**

--- a/app/main/Take/Take.js
+++ b/app/main/Take/Take.js
@@ -39,6 +39,11 @@
       this.onionSkin = new OnionSkin();
       // Id of the last exported frame
       this.exportFrameId = 0;
+      // Create a unique id for the take based on the current unix time
+      // Used when generating the file names
+      this.uniqueId = Math.floor(new Date().getTime() / 1000);
+
+      console.log(`Created take ${this.takeNumber} with id ${this.uniqueId}`);
     }
 
     /**
@@ -128,8 +133,8 @@
         for (let i = 0; i < self.getTotalFrames(); i++) {
           let oldFilePath = self.exportedFramesPaths[i];
 
-          let newFileName = `frame_${Take.getPaddedFrameNumber(i+1)}`;
-          let newFilePath = `${outputDir}/${newFileName}.png`;
+          let newFileName = this.buildFileName(Take.getPaddedFrameNumber(i+1));
+          let newFilePath = `${outputDir}/${newFileName}`;
 
           // Rename the file to the updated name
           self.exportedFramesPaths[i] = newFilePath;
@@ -187,14 +192,7 @@
     _exportFrame(blob) {
       this.exportFrameId++;
       let id = this.exportFrameId;
-      let fileName = "";
-
-      // 1K+ frames have been captured
-      if (id >= 1000) {
-        fileName = `frame_${id}`;
-      } else {
-        fileName = `frame_${Take.getPaddedFrameNumber(id)}`
-      }
+      let fileName = this.buildFileName(Take.getPaddedFrameNumber(id));
 
       // Make the output directory if it does not exist
       // todo outputDir should eventually be ${this.saveDirectory.saveDirLocation}/${this.takeNumber}
@@ -204,7 +202,7 @@
       }
 
       // Create an absolute path to the destination location
-      var outputPath = `${outputDir}/${fileName}.png`;
+      var outputPath = `${outputDir}/${fileName}`;
 
       // Save the frame to disk
       var reader = new FileReader()
@@ -213,7 +211,7 @@
         var buffer = new Buffer.from(reader.result);
         File.write(outputPath, buffer);
       }
-      reader.readAsArrayBuffer(blob)
+      reader.readAsArrayBuffer(blob);
 
       // Store the location of the exported frame
       this.exportedFramesPaths.push(outputPath);
@@ -233,11 +231,20 @@
     }
 
     /**
+     * Makes the file name for a frame with a given id
+     * @param {String} frameId The id of the frame (or some clever wildcard thing)
+     */
+    buildFileName(frameId) {
+      return `ba_${this.uniqueId}_frame_${frameId}.png`;
+    }
+
+    /**
      * Converts a frame number into the padded zero format used in file names.
      * @param {Integer} frameNumber 
      */
     static getPaddedFrameNumber(frameNumber) {
-      let zeros = "0000";
+      // Note the massive assumption that no one will capture more than 99999 frames has been made
+      let zeros = "00000";
       return `${zeros.substring(0, zeros.length - frameNumber.toString().length)}${frameNumber}`;
     }
   }


### PR DESCRIPTION
This adds a unique id to each take generated from the current Linux epoch time. I also made frame ids 5 digits long rather than 4

This will fix issue #272 and one of the most unintuitive "features" of the app where frames will be overwritten if you don't choose a new directory each time you start the app

It's true that technically if a user were to create 2 projects in the same second, or change their PCs clock back frames could still be overwritten with this change. However this is highly unlikely and this will do until a project system is fully implemented.