### PR TITLE
Fix bugs with confirmTake

### DIFF
--- a/src/js/animator/core/ExportVideo.js
+++ b/src/js/animator/core/ExportVideo.js
@@ -4,7 +4,7 @@
   const path = require("path");
 
   const ConfirmDialog = require("../ui/ConfirmDialog");
-  const Loader = require("./Loader");
+  const Notification = require("../../common/Notification");
 
   const DEFAULT_FILE_NAME = "output.mp4";
 
@@ -96,14 +96,12 @@
         content: dialogContents,
         buttons: [true, "Export video"]
       })
-      .then((response) => {
+      .then(async (response) => {
         // Confirm the take and render the video if "export video" selected
         if (response) {
-          Loader.show("Confirming take");
-          global.projectInst.currentTake.confirmTake(false)
-          .then(() => {
-            Loader.hide();
+          let isTakeConfirmed = await global.projectInst.currentTake.confirmTake(false);
 
+          if (isTakeConfirmed) {
             // The render method expects an array so convert input from string into array
             // Regexes are to handle arguments in quotes
             // https://stackoverflow.com/a/56119602
@@ -111,7 +109,9 @@
             argumentsArray = argumentsArray.map((arg) => arg.replace(/"|'/g, ""));
 
             ExportVideo.render(argumentsArray, outputPath);
-          });
+          } else {
+            Notification.error("Unable to export video due to an error renaming files with confirm take.");
+          }
         }
       });
 

--- a/src/js/animator/projects/Take.js
+++ b/src/js/animator/projects/Take.js
@@ -2,17 +2,18 @@
   "use strict";
 
   // UI imports
-  var FrameReel = require("../core/FrameReel");
-  var Notification = require("../../common/Notification");
-  var OnionSkin = require("../ui/OnionSkin");
-  var PlaybackCanvas = require("../ui/PlaybackCanvas");
-  var StatusBar = require("../ui/StatusBar");
+  const FrameReel = require("../core/FrameReel");
+  const Loader = require("../core/Loader");
+  const Notification = require("../../common/Notification");
+  const OnionSkin = require("../ui/OnionSkin");
+  const PlaybackCanvas = require("../ui/PlaybackCanvas");
+  const StatusBar = require("../ui/StatusBar");
 
   // Common imports
-  var AudioManager = require("../core/AudioManager");
-  var File = require("../core/File");
+  const AudioManager = require("../core/AudioManager");
+  const File = require("../core/File");
 
-  var preview = document.querySelector("#preview");
+  const preview = document.querySelector("#preview");
 
   /** Represents a single take (image sequence). */
   class Take {
@@ -117,18 +118,23 @@
 
     /**
      * "Confirms" a take by renaming each captured frame to be sequential.
+     * @param {Boolean} notify Display a notification when the process completes/fails
+     * @returns {Boolean} Returns true if confirm is successful, false if there is an error
      */
     async confirmTake(notify = true) {
       let self = this;
       let outputDir = this.saveDirPath;
       let promisesList = [];
+      let response = null;
 
       // Return if no captured frames
       if (this.getTotalFrames() < 1) {
-        return;
+        return true;
       }
 
       try {
+        Loader.show("Confirming take");
+
         // Give all of the files a temporary name
         // (required because async renaming could cause naming conflicts otherwise)
         for (let i = 0; i < self.getTotalFrames(); i++) {
@@ -158,13 +164,17 @@
         if (notify) {
           Notification.success("Confirm take successfully completed");
         }
-        return;
+        response = true;
 
       } catch (err) {
         if (notify) {
           Notification.error("Error renaming file with confirm take");
         }
-        return err;
+        response = false;
+
+      } finally {
+        Loader.hide();
+        return response;
       }
     }
 


### PR DESCRIPTION
Fixes #289 by adding an extra step of giving files a temporary name in the `confirmTake()` method.