### PR TITLE
Option to switch status bar time between frames and seconds

### DIFF
--- a/src/common/UserPreferences.ts
+++ b/src/common/UserPreferences.ts
@@ -1,11 +1,13 @@
 export interface UserPreferences {
   playCaptureSound: boolean;
   shortPlayLength: number;
+  showTimestampInSeconds: boolean;
   workingDirectory: string | undefined;
 }
 
 export const defaultUserPreferences: UserPreferences = {
   playCaptureSound: true,
   shortPlayLength: 6,
+  showTimestampInSeconds: false,
   workingDirectory: undefined,
 };

--- a/src/common/timeUtils.test.ts
+++ b/src/common/timeUtils.test.ts
@@ -5,10 +5,12 @@ describe("secondsToTimeCode", () => {
     expect(secondsToTimeCode(0, true)).toBe("00:00.000");
     expect(secondsToTimeCode(0.01, true)).toBe("00:00.010");
     expect(secondsToTimeCode(0.999, true)).toBe("00:00.999");
+    expect(secondsToTimeCode(0.9999, true)).toBe("00:01.000");
     expect(secondsToTimeCode(1, true)).toBe("00:01.000");
     expect(secondsToTimeCode(1.1, true)).toBe("00:01.100");
     expect(secondsToTimeCode(1.6664, true)).toBe("00:01.666");
     expect(secondsToTimeCode(1.6665, true)).toBe("00:01.667");
+    expect(secondsToTimeCode(59, true)).toBe("00:59.000");
     expect(secondsToTimeCode(60, true)).toBe("01:00.000");
     expect(secondsToTimeCode(61, true)).toBe("01:01.000");
     expect(secondsToTimeCode(600, true)).toBe("10:00.000");
@@ -21,16 +23,18 @@ describe("secondsToTimeCode", () => {
   it("should convert to correct time codes when show decimal is false", () => {
     expect(secondsToTimeCode(0, false)).toBe("00:00");
     expect(secondsToTimeCode(0.01, false)).toBe("00:00");
-    expect(secondsToTimeCode(0.999, false)).toBe("00:00");
+    expect(secondsToTimeCode(0.999, false)).toBe("00:01");
+    expect(secondsToTimeCode(0.9999, false)).toBe("00:01");
     expect(secondsToTimeCode(1, false)).toBe("00:01");
     expect(secondsToTimeCode(1.1, false)).toBe("00:01");
-    expect(secondsToTimeCode(1.6664, false)).toBe("00:01");
-    expect(secondsToTimeCode(1.6665, false)).toBe("00:01");
+    expect(secondsToTimeCode(1.6664, false)).toBe("00:02");
+    expect(secondsToTimeCode(1.6665, false)).toBe("00:02");
+    expect(secondsToTimeCode(59, false)).toBe("00:59");
     expect(secondsToTimeCode(60, false)).toBe("01:00");
     expect(secondsToTimeCode(61, false)).toBe("01:01");
     expect(secondsToTimeCode(600, false)).toBe("10:00");
     expect(secondsToTimeCode(601, false)).toBe("10:01");
-    expect(secondsToTimeCode(601.789, false)).toBe("10:01");
+    expect(secondsToTimeCode(601.789, false)).toBe("10:02");
     expect(secondsToTimeCode(5999, false)).toBe("99:59");
     expect(secondsToTimeCode(6000, false)).toBe("100:00");
   });

--- a/src/common/timeUtils.test.ts
+++ b/src/common/timeUtils.test.ts
@@ -7,7 +7,8 @@ describe("secondsToTimeCode", () => {
     expect(secondsToTimeCode(0.999, true)).toBe("00:00.999");
     expect(secondsToTimeCode(1, true)).toBe("00:01.000");
     expect(secondsToTimeCode(1.1, true)).toBe("00:01.100");
-    expect(secondsToTimeCode(1.66667, true)).toBe("00:01.667");
+    expect(secondsToTimeCode(1.6664, true)).toBe("00:01.666");
+    expect(secondsToTimeCode(1.6665, true)).toBe("00:01.667");
     expect(secondsToTimeCode(60, true)).toBe("01:00.000");
     expect(secondsToTimeCode(61, true)).toBe("01:01.000");
     expect(secondsToTimeCode(600, true)).toBe("10:00.000");
@@ -23,7 +24,8 @@ describe("secondsToTimeCode", () => {
     expect(secondsToTimeCode(0.999, false)).toBe("00:00");
     expect(secondsToTimeCode(1, false)).toBe("00:01");
     expect(secondsToTimeCode(1.1, false)).toBe("00:01");
-    expect(secondsToTimeCode(1.66667, false)).toBe("00:01");
+    expect(secondsToTimeCode(1.6664, false)).toBe("00:01");
+    expect(secondsToTimeCode(1.6665, false)).toBe("00:01");
     expect(secondsToTimeCode(60, false)).toBe("01:00");
     expect(secondsToTimeCode(61, false)).toBe("01:01");
     expect(secondsToTimeCode(600, false)).toBe("10:00");

--- a/src/common/timeUtils.test.ts
+++ b/src/common/timeUtils.test.ts
@@ -1,7 +1,7 @@
-import { secondsToTimeCode } from "./timeUtils";
+import { buildStartTimeCode, secondsToTimeCode } from "./timeUtils";
 
 describe("secondsToTimeCode", () => {
-  it("should display correct time codes when show decimal is true", () => {
+  it("should convert to correct time codes when show decimal is true", () => {
     expect(secondsToTimeCode(0, true)).toBe("00:00.000");
     expect(secondsToTimeCode(0.01, true)).toBe("00:00.010");
     expect(secondsToTimeCode(0.999, true)).toBe("00:00.999");
@@ -17,7 +17,7 @@ describe("secondsToTimeCode", () => {
     expect(secondsToTimeCode(6000, true)).toBe("100:00.000");
   });
 
-  it("should display correct time codes when show decimal is false", () => {
+  it("should convert to correct time codes when show decimal is false", () => {
     expect(secondsToTimeCode(0, false)).toBe("00:00");
     expect(secondsToTimeCode(0.01, false)).toBe("00:00");
     expect(secondsToTimeCode(0.999, false)).toBe("00:00");
@@ -28,12 +28,41 @@ describe("secondsToTimeCode", () => {
     expect(secondsToTimeCode(61, false)).toBe("01:01");
     expect(secondsToTimeCode(600, false)).toBe("10:00");
     expect(secondsToTimeCode(601, false)).toBe("10:01");
-    expect(secondsToTimeCode(601.789, true)).toBe("10:01.789");
+    expect(secondsToTimeCode(601.789, false)).toBe("10:01");
     expect(secondsToTimeCode(5999, false)).toBe("99:59");
     expect(secondsToTimeCode(6000, false)).toBe("100:00");
   });
 
-  it("should display time code with decimal by default", () => {
+  it("should convert to time code with decimal by default", () => {
     expect(secondsToTimeCode(60)).toBe("01:00.000");
+  });
+});
+
+describe("buildStartTimeCode", () => {
+  it("should build correct time codes for frame positions", () => {
+    // 15 FPS
+    expect(buildStartTimeCode(0, 15, true)).toBe("00:00.000");
+    expect(buildStartTimeCode(1, 15, true)).toBe("00:00.067");
+    expect(buildStartTimeCode(14, 15, true)).toBe("00:00.933");
+    expect(buildStartTimeCode(15, 15, true)).toBe("00:01.000");
+    expect(buildStartTimeCode(16, 15, true)).toBe("00:01.067");
+    expect(buildStartTimeCode(999, 15, true)).toBe("01:06.600");
+    expect(buildStartTimeCode(9999, 15, true)).toBe("11:06.600");
+    // 12 FPS
+    expect(buildStartTimeCode(0, 12, true)).toBe("00:00.000");
+    expect(buildStartTimeCode(1, 12, true)).toBe("00:00.083");
+    expect(buildStartTimeCode(11, 12, true)).toBe("00:00.917");
+    expect(buildStartTimeCode(12, 12, true)).toBe("00:01.000");
+    expect(buildStartTimeCode(13, 12, true)).toBe("00:01.083");
+    expect(buildStartTimeCode(999, 12, true)).toBe("01:23.250");
+    expect(buildStartTimeCode(9999, 12, true)).toBe("13:53.250");
+  });
+
+  it("should build time code for frame position when showDecimal is false", () => {
+    expect(buildStartTimeCode(16, 15, false)).toBe("00:01");
+  });
+
+  it("should build time code for frame position with decimal by default", () => {
+    expect(buildStartTimeCode(16, 15)).toBe("00:01.067");
   });
 });

--- a/src/common/timeUtils.test.ts
+++ b/src/common/timeUtils.test.ts
@@ -1,0 +1,39 @@
+import { secondsToTimeCode } from "./timeUtils";
+
+describe("secondsToTimeCode", () => {
+  it("should display correct time codes when show decimal is true", () => {
+    expect(secondsToTimeCode(0, true)).toBe("00:00.000");
+    expect(secondsToTimeCode(0.01, true)).toBe("00:00.010");
+    expect(secondsToTimeCode(0.999, true)).toBe("00:00.999");
+    expect(secondsToTimeCode(1, true)).toBe("00:01.000");
+    expect(secondsToTimeCode(1.1, true)).toBe("00:01.100");
+    expect(secondsToTimeCode(1.66667, true)).toBe("00:01.667");
+    expect(secondsToTimeCode(60, true)).toBe("01:00.000");
+    expect(secondsToTimeCode(61, true)).toBe("01:01.000");
+    expect(secondsToTimeCode(600, true)).toBe("10:00.000");
+    expect(secondsToTimeCode(601, true)).toBe("10:01.000");
+    expect(secondsToTimeCode(601.789, true)).toBe("10:01.789");
+    expect(secondsToTimeCode(5999, true)).toBe("99:59.000");
+    expect(secondsToTimeCode(6000, true)).toBe("100:00.000");
+  });
+
+  it("should display correct time codes when show decimal is false", () => {
+    expect(secondsToTimeCode(0, false)).toBe("00:00");
+    expect(secondsToTimeCode(0.01, false)).toBe("00:00");
+    expect(secondsToTimeCode(0.999, false)).toBe("00:00");
+    expect(secondsToTimeCode(1, false)).toBe("00:01");
+    expect(secondsToTimeCode(1.1, false)).toBe("00:01");
+    expect(secondsToTimeCode(1.66667, false)).toBe("00:01");
+    expect(secondsToTimeCode(60, false)).toBe("01:00");
+    expect(secondsToTimeCode(61, false)).toBe("01:01");
+    expect(secondsToTimeCode(600, false)).toBe("10:00");
+    expect(secondsToTimeCode(601, false)).toBe("10:01");
+    expect(secondsToTimeCode(601.789, true)).toBe("10:01.789");
+    expect(secondsToTimeCode(5999, false)).toBe("99:59");
+    expect(secondsToTimeCode(6000, false)).toBe("100:00");
+  });
+
+  it("should display time code with decimal by default", () => {
+    expect(secondsToTimeCode(60)).toBe("01:00.000");
+  });
+});

--- a/src/common/timeUtils.ts
+++ b/src/common/timeUtils.ts
@@ -1,14 +1,23 @@
 import { FrameRate, TimelineIndex } from "./Flavors";
 import { zeroPad } from "./utils";
 
-export const secondsToTimeCode = (seconds: number) => {
-  const minuteComponent = (seconds - (seconds % 60)) / 60;
-  const secondComponent = seconds % 60;
+export const secondsToTimeCode = (seconds: number, showDecimal = true) => {
+  const minuteComponent = Math.floor(seconds / 60);
+  const secondComponent = Math.floor(seconds % 60);
+  const decimalComponent = Math.round(((seconds % 60) % 1) * 1000);
 
-  return [zeroPad(minuteComponent, 2), zeroPad(secondComponent, 2)].join(":");
+  return [
+    zeroPad(minuteComponent, 2),
+    `:${zeroPad(secondComponent, 2)}`,
+    showDecimal ? `.${zeroPad(decimalComponent, 3)}` : undefined,
+  ].join("");
 };
 
-export const buildTimeCode = (framePosition: TimelineIndex, frameRate: FrameRate) => {
+export const buildTimeCode = (
+  framePosition: TimelineIndex,
+  frameRate: FrameRate,
+  showDecimal?: boolean
+) => {
   const timeInSeconds = framePosition / frameRate;
-  return secondsToTimeCode(timeInSeconds);
+  return secondsToTimeCode(timeInSeconds, showDecimal);
 };

--- a/src/common/timeUtils.ts
+++ b/src/common/timeUtils.ts
@@ -2,15 +2,16 @@ import { FrameRate, TimelineIndex } from "./Flavors";
 import { zeroPad } from "./utils";
 
 export const secondsToTimeCode = (seconds: number, showDecimal = true) => {
-  const minuteComponent = Math.floor(seconds / 60);
-  const secondComponent = Math.floor(seconds % 60);
-  const decimalComponent = Math.round(((seconds % 60) % 1) * 1000);
+  const roundedSeconds = seconds.toFixed(showDecimal ? 3 : 0);
+  const [fullSeconds, millisecondComponent] = roundedSeconds.split(".");
 
-  return [
-    zeroPad(minuteComponent, 2),
-    `:${zeroPad(secondComponent, 2)}`,
-    showDecimal ? `.${zeroPad(decimalComponent, 3)}` : undefined,
-  ].join("");
+  const minuteComponent = Math.floor(parseInt(fullSeconds, 10) / 60);
+  const secondComponent = parseInt(fullSeconds, 10) % 60;
+  const paddedMinutesAndSeconds = `${zeroPad(minuteComponent, 2)}:${zeroPad(secondComponent, 2)}`;
+
+  return showDecimal
+    ? `${paddedMinutesAndSeconds}.${millisecondComponent}`
+    : paddedMinutesAndSeconds;
 };
 
 export const buildStartTimeCode = (

--- a/src/common/timeUtils.ts
+++ b/src/common/timeUtils.ts
@@ -13,7 +13,7 @@ export const secondsToTimeCode = (seconds: number, showDecimal = true) => {
   ].join("");
 };
 
-export const buildTimeCode = (
+export const buildStartTimeCode = (
   framePosition: TimelineIndex,
   frameRate: FrameRate,
   showDecimal?: boolean

--- a/src/common/timeUtils.ts
+++ b/src/common/timeUtils.ts
@@ -1,0 +1,14 @@
+import { FrameRate, TimelineIndex } from "./Flavors";
+import { zeroPad } from "./utils";
+
+export const secondsToTimeCode = (seconds: number) => {
+  const minuteComponent = (seconds - (seconds % 60)) / 60;
+  const secondComponent = seconds % 60;
+
+  return [zeroPad(minuteComponent, 2), zeroPad(secondComponent, 2)].join(":");
+};
+
+export const buildTimeCode = (framePosition: TimelineIndex, frameRate: FrameRate) => {
+  const timeInSeconds = framePosition / frameRate;
+  return secondsToTimeCode(timeInSeconds);
+};

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -4,13 +4,6 @@ export const zeroPad = (value: number, length: number) => {
   return `${zeros.substring(0, zeros.length - value.toString().length)}${value}`;
 };
 
-export const secondsToTimeCode = (seconds: number) => {
-  const minuteComponent = (seconds - (seconds % 60)) / 60;
-  const secondComponent = seconds % 60;
-
-  return [zeroPad(minuteComponent, 2), zeroPad(secondComponent, 2)].join(":");
-};
-
 export const stringToArray = (items: string) =>
   // Regexes are to handle arguments in quotes
   // https://stackoverflow.com/a/56119602

--- a/src/renderer/components/animator/Animator/Animator.tsx
+++ b/src/renderer/components/animator/Animator/Animator.tsx
@@ -11,7 +11,7 @@ import AnimationToolbarWithContext from "../AnimationToolbar/AnimationToolbar";
 import CaptureButtonToolbarWithContext from "../CaptureButtonToolbar/CaptureButtonToolbar";
 import CaptureSidebarBlock from "../CaptureSidebarBlock/CaptureSidebarBlock";
 import Preview from "../Preview/Preview";
-import StatusToolbarWithContext from "../StatusToolbar/StatusToolbar";
+import StatusToolbar from "../StatusToolbar/StatusToolbar";
 import Timeline from "../Timeline/Timeline";
 import TitleToolbar from "../TitleToolbar/TitleToolbar";
 
@@ -25,7 +25,7 @@ const Animator = ({ take }: AnimatorWithProviderProps): JSX.Element => {
       <TitleToolbar take={take} />
       <PageBody>
         <Content>
-          <StatusToolbarWithContext take={take} />
+          <StatusToolbar take={take} />
           <Preview take={take} />
           <CaptureButtonToolbarWithContext />
           <AnimationToolbarWithContext />

--- a/src/renderer/components/animator/StatusToolbar/StatusToolbar.tsx
+++ b/src/renderer/components/animator/StatusToolbar/StatusToolbar.tsx
@@ -1,35 +1,19 @@
-import { TimelineIndex } from "../../../../common/Flavors";
 import { Take } from "../../../../common/project/Take";
-import PlaybackContext from "../../../context/PlaybackContext/PlaybackContext";
-import { getTrackLength } from "../../../services/project/projectCalculator";
 import Toolbar from "../../common/Toolbar/Toolbar";
 import ToolbarItem, { ToolbarItemAlign } from "../../common/ToolbarItem/ToolbarItem";
 import "./StatusToolbar.css";
+import StatusToolbarTimestampWithContext from "./StatusToolbarTimestamp/StatusToolbarTimestamp";
 
-interface StatusToolbarWithContextProps {
+interface StatusToolbarProps {
   take: Take;
 }
 
-interface StatusToolbarProps extends StatusToolbarWithContextProps {
-  timelineIndex: TimelineIndex | undefined;
-}
-
-const StatusToolbar = ({ take, timelineIndex }: StatusToolbarProps): JSX.Element => (
+const StatusToolbar = ({ take }: StatusToolbarProps): JSX.Element => (
   <Toolbar className="status-toolbar">
     <ToolbarItem align={ToolbarItemAlign.CENTER}>
-      <div>
-        Frame{" "}
-        {timelineIndex === undefined ? getTrackLength(take.frameTrack) + 1 : timelineIndex + 1} of{" "}
-        {getTrackLength(take.frameTrack)}
-      </div>
+      <StatusToolbarTimestampWithContext take={take} />
     </ToolbarItem>
   </Toolbar>
 );
 
-const StatusToolbarWithContext = (props: StatusToolbarWithContextProps) => (
-  <PlaybackContext.Consumer>
-    {(value) => <StatusToolbar timelineIndex={value.timelineIndex} {...props} />}
-  </PlaybackContext.Consumer>
-);
-
-export default StatusToolbarWithContext;
+export default StatusToolbar;

--- a/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.css
+++ b/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.css
@@ -1,0 +1,3 @@
+.status-toolbar-timestamp {
+  font-family: monospace;
+}

--- a/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
+++ b/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
@@ -5,6 +5,7 @@ import PlaybackContext from "../../../../context/PlaybackContext/PlaybackContext
 import { getTrackLength } from "../../../../services/project/projectCalculator";
 import Button from "../../../common/Button/Button";
 import { ButtonColor } from "../../../common/Button/ButtonColor";
+import { buildTimeCode } from "../../../../../common/timeUtils";
 
 interface StatusToolbarTimestampWithContextProps {
   take: Take;
@@ -20,13 +21,17 @@ const StatusToolbarTimestamp = ({
 }: StatusToolbarTimestampProps): JSX.Element => {
   const [showInSeconds, setShowInSeconds] = useState(false);
 
-  const secondsText = "00:00.00 / 00:09.83";
-
+  const trackLength = getTrackLength(take.frameTrack);
+  const secondsText = [
+    buildTimeCode(timelineIndex ?? (trackLength as TimelineIndex), take.frameRate),
+    "/",
+    buildTimeCode(trackLength as TimelineIndex, take.frameRate),
+  ].join(" ");
   const frameText = [
     "Frame",
-    timelineIndex === undefined ? getTrackLength(take.frameTrack) + 1 : timelineIndex + 1,
+    timelineIndex === undefined ? trackLength + 1 : timelineIndex + 1,
     "of",
-    getTrackLength(take.frameTrack),
+    trackLength,
   ].join(" ");
 
   return (

--- a/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
+++ b/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
@@ -7,6 +7,8 @@ import Button from "../../../common/Button/Button";
 import { ButtonColor } from "../../../common/Button/ButtonColor";
 import { buildStartTimeCode } from "../../../../../common/timeUtils";
 import "./StatusToolbarTimestamp.css";
+import { useSelector } from "react-redux";
+import { RootState } from "../../../../redux/store";
 
 interface StatusToolbarTimestampWithContextProps {
   take: Take;
@@ -20,7 +22,8 @@ const StatusToolbarTimestamp = ({
   take,
   timelineIndex,
 }: StatusToolbarTimestampProps): JSX.Element => {
-  const [showInSeconds, setShowInSeconds] = useState(false);
+  const { showTimestampInSeconds } = useSelector((state: RootState) => state.app.userPreferences);
+  const [showInSeconds, setShowInSeconds] = useState(showTimestampInSeconds);
 
   const trackLength = getTrackLength(take.frameTrack);
   const secondsText = [

--- a/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
+++ b/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
@@ -5,7 +5,7 @@ import PlaybackContext from "../../../../context/PlaybackContext/PlaybackContext
 import { getTrackLength } from "../../../../services/project/projectCalculator";
 import Button from "../../../common/Button/Button";
 import { ButtonColor } from "../../../common/Button/ButtonColor";
-import { buildTimeCode } from "../../../../../common/timeUtils";
+import { buildStartTimeCode } from "../../../../../common/timeUtils";
 import "./StatusToolbarTimestamp.css";
 
 interface StatusToolbarTimestampWithContextProps {
@@ -24,9 +24,9 @@ const StatusToolbarTimestamp = ({
 
   const trackLength = getTrackLength(take.frameTrack);
   const secondsText = [
-    buildTimeCode(timelineIndex ?? (trackLength as TimelineIndex), take.frameRate),
+    buildStartTimeCode(timelineIndex ?? (trackLength as TimelineIndex), take.frameRate),
     "/",
-    buildTimeCode(trackLength as TimelineIndex, take.frameRate),
+    buildStartTimeCode(trackLength as TimelineIndex, take.frameRate),
   ].join(" ");
   const frameText = [
     "Frame",

--- a/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
+++ b/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { TimelineIndex } from "../../../../../common/Flavors";
+import { Take } from "../../../../../common/project/Take";
+import PlaybackContext from "../../../../context/PlaybackContext/PlaybackContext";
+import { getTrackLength } from "../../../../services/project/projectCalculator";
+import Button from "../../../common/Button/Button";
+import { ButtonColor } from "../../../common/Button/ButtonColor";
+
+interface StatusToolbarTimestampWithContextProps {
+  take: Take;
+}
+
+interface StatusToolbarTimestampProps extends StatusToolbarTimestampWithContextProps {
+  timelineIndex: TimelineIndex | undefined;
+}
+
+const StatusToolbarTimestamp = ({
+  take,
+  timelineIndex,
+}: StatusToolbarTimestampProps): JSX.Element => {
+  const [showInSeconds, setShowInSeconds] = useState(false);
+
+  const secondsText = "00:00.00 / 00:09.83";
+
+  const frameText = [
+    "Frame",
+    timelineIndex === undefined ? getTrackLength(take.frameTrack) + 1 : timelineIndex + 1,
+    "of",
+    getTrackLength(take.frameTrack),
+  ].join(" ");
+
+  return (
+    <Button
+      label={showInSeconds ? secondsText : frameText}
+      title={showInSeconds ? "Show timestamp in frames" : "Show timestamp in seconds"}
+      onClick={() => setShowInSeconds((prevState) => !prevState)}
+      color={ButtonColor.TRANSPARENT}
+    />
+  );
+};
+
+const StatusToolbarTimestampWithContext = (props: StatusToolbarTimestampWithContextProps) => (
+  <PlaybackContext.Consumer>
+    {(value) => <StatusToolbarTimestamp timelineIndex={value.timelineIndex} {...props} />}
+  </PlaybackContext.Consumer>
+);
+
+export default StatusToolbarTimestampWithContext;

--- a/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
+++ b/src/renderer/components/animator/StatusToolbar/StatusToolbarTimestamp/StatusToolbarTimestamp.tsx
@@ -6,6 +6,7 @@ import { getTrackLength } from "../../../../services/project/projectCalculator";
 import Button from "../../../common/Button/Button";
 import { ButtonColor } from "../../../common/Button/ButtonColor";
 import { buildTimeCode } from "../../../../../common/timeUtils";
+import "./StatusToolbarTimestamp.css";
 
 interface StatusToolbarTimestampWithContextProps {
   take: Take;
@@ -36,6 +37,7 @@ const StatusToolbarTimestamp = ({
 
   return (
     <Button
+      className="status-toolbar-timestamp"
       label={showInSeconds ? secondsText : frameText}
       title={showInSeconds ? "Show timestamp in frames" : "Show timestamp in seconds"}
       onClick={() => setShowInSeconds((prevState) => !prevState)}

--- a/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.tsx
+++ b/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.tsx
@@ -1,5 +1,5 @@
 import { FrameCount, FrameRate, TimelineIndex } from "../../../../../common/Flavors";
-import { buildTimeCode } from "../../../../../common/timeUtils";
+import { buildStartTimeCode } from "../../../../../common/timeUtils";
 import "./TimelinePosition.css";
 
 interface TimelinePositionProps {
@@ -16,7 +16,7 @@ const TimelinePosition = ({ frameRate, totalFrames }: TimelinePositionProps): JS
       <div className="timeline-position__inner">
         {frameNumbers.map((i: TimelineIndex) => (
           <div className="timeline-position__marker" key={i}>
-            {i % frameRate === 0 && buildTimeCode(i, frameRate, false)}
+            {i % frameRate === 0 && buildStartTimeCode(i, frameRate, false)}
             <br />
             {i + 1}
           </div>

--- a/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.tsx
+++ b/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.tsx
@@ -1,26 +1,22 @@
-import { secondsToTimeCode } from "../../../../../common/utils";
+import { FrameCount, FrameRate, TimelineIndex } from "../../../../../common/Flavors";
+import { buildTimeCode } from "../../../../../common/timeUtils";
 import "./TimelinePosition.css";
 
 interface TimelinePositionProps {
-  frameRate: number;
-  totalFrames: number;
+  frameRate: FrameRate;
+  totalFrames: FrameCount;
 }
 
 const TimelinePosition = ({ frameRate, totalFrames }: TimelinePositionProps): JSX.Element => {
-  const frameCount = totalFrames < 30 ? 30 : totalFrames;
+  const frameCount: FrameCount = totalFrames < 30 ? 30 : totalFrames;
   const frameNumbers = [...Array(frameCount).keys()];
-
-  const buildTimeCode = (framePosition: number) => {
-    const timeInSeconds = framePosition / frameRate;
-    return secondsToTimeCode(timeInSeconds);
-  };
 
   return (
     <div className="timeline-position">
       <div className="timeline-position__inner">
-        {frameNumbers.map((i) => (
+        {frameNumbers.map((i: TimelineIndex) => (
           <div className="timeline-position__marker" key={i}>
-            {i % frameRate === 0 && buildTimeCode(i)}
+            {i % frameRate === 0 && buildTimeCode(i, frameRate)}
             <br />
             {i + 1}
           </div>

--- a/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.tsx
+++ b/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.tsx
@@ -16,7 +16,7 @@ const TimelinePosition = ({ frameRate, totalFrames }: TimelinePositionProps): JS
       <div className="timeline-position__inner">
         {frameNumbers.map((i: TimelineIndex) => (
           <div className="timeline-position__marker" key={i}>
-            {i % frameRate === 0 && buildTimeCode(i, frameRate)}
+            {i % frameRate === 0 && buildTimeCode(i, frameRate, false)}
             <br />
             {i + 1}
           </div>

--- a/src/renderer/components/modals/PreferencesModal/PreferencesModal.tsx
+++ b/src/renderer/components/modals/PreferencesModal/PreferencesModal.tsx
@@ -73,6 +73,23 @@ const PreferencesModal = (): JSX.Element => {
                     validateOnChange
                   />
                 </InputGroup>
+
+                <InputGroup row>
+                  <InputSwitch
+                    id="preferencesShowTimestampInSeconds"
+                    checked={userPreferences.showTimestampInSeconds}
+                    onChange={() =>
+                      dispatch(
+                        editUserPreferences({
+                          showTimestampInSeconds: !userPreferences.showTimestampInSeconds,
+                        })
+                      )
+                    }
+                  />
+                  <InputLabel inputId="preferencesShowTimestampInSeconds">
+                    Show timestamp in seconds on startup
+                  </InputLabel>
+                </InputGroup>
               </ContentBlock>
             </Content>
           </PageBody>


### PR DESCRIPTION
* The status bar current frame indicator is now a button that switches between displaying frames and seconds #419 
* Adds a setting "show timestamp in seconds on startup" to show seconds rather than frames on start up.


![image](https://user-images.githubusercontent.com/8095888/237049584-1949be3d-c732-40dc-8950-3eb20b50f948.png)

![image](https://user-images.githubusercontent.com/8095888/237049611-fb362b97-9c2f-4936-9be7-66053168f372.png)
