### PR TITLE
Keep timeline track labels in place when timeline scrolls

### DIFF
--- a/src/renderer/components/animator/Timeline/Timeline.css
+++ b/src/renderer/components/animator/Timeline/Timeline.css
@@ -9,7 +9,7 @@
 
 .timeline__track-labels-inner {
   background-color: var(--ba-dark);
-  margin: var(--height-200) 0 0 0;
+  margin-top: var(--height-200);
 }
 
 .timeline__tracks {

--- a/src/renderer/components/animator/Timeline/Timeline.css
+++ b/src/renderer/components/animator/Timeline/Timeline.css
@@ -1,8 +1,23 @@
 .timeline {
+  display: flex;
+}
+
+.timeline__track-labels {
+  background-color: var(--ba-dark-mid-hover);
+  border-right: var(--border-1) solid var(--ba-border);
+}
+
+.timeline__track-labels-inner {
+  background-color: var(--ba-dark);
+  margin: var(--height-200) 0 0 0;
+}
+
+.timeline__tracks {
+  flex: 1;
   overflow-x: scroll;
 }
 
-.timeline__inner {
+.timeline__tracks-inner {
   width: max-content;
   min-width: 100%;
 }

--- a/src/renderer/components/animator/Timeline/Timeline.tsx
+++ b/src/renderer/components/animator/Timeline/Timeline.tsx
@@ -7,6 +7,7 @@ import { getTrackItemStartPosition } from "../../../services/project/projectCalc
 import "./Timeline.css";
 import TimelinePosition from "./TimelinePosition/TimelinePosition";
 import TimelineTrack from "./TimelineTrack/TimelineTrack";
+import TimelineTrackLabel from "./TimelineTrackLabel/TimelineTrackLabel";
 
 interface TimelineWithContextProps {
   take: Take;
@@ -19,11 +20,11 @@ interface TimelineProps extends TimelineWithContextProps {
 
 const Timeline = ({ take, timelineIndex, stopPlayback }: TimelineProps): JSX.Element => {
   const frameTrack = take.frameTrack;
-  const timelineRef = useRef<HTMLDivElement>(null);
+  const timelineTracksRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (timelineRef.current && timelineIndex === undefined) {
-      timelineRef.current.scrollLeft = timelineRef.current.scrollWidth;
+    if (timelineTracksRef.current && timelineIndex === undefined) {
+      timelineTracksRef.current.scrollLeft = timelineTracksRef.current.scrollWidth;
     }
   }, [timelineIndex, frameTrack.trackItems]);
 
@@ -31,16 +32,23 @@ const Timeline = ({ take, timelineIndex, stopPlayback }: TimelineProps): JSX.Ele
     stopPlayback(getTrackItemStartPosition(track, trackItemIndex));
 
   return (
-    <div className="timeline" ref={timelineRef}>
-      <div className="timeline__inner">
-        <TimelinePosition frameRate={take.frameRate} totalFrames={frameTrack.trackItems.length} />
-        <TimelineTrack
-          track={frameTrack}
-          key={frameTrack.id}
-          timelineIndex={timelineIndex}
-          onClickItem={(trackItemIndex) => onClickItem(frameTrack, trackItemIndex)}
-          onClickLiveView={() => stopPlayback()}
-        />
+    <div className="timeline">
+      <div className="timeline__track-labels">
+        <div className="timeline__track-labels-inner">
+          <TimelineTrackLabel fileType={frameTrack.fileType} />
+        </div>
+      </div>
+      <div className="timeline__tracks" ref={timelineTracksRef}>
+        <div className="timeline__tracks-inner">
+          <TimelinePosition frameRate={take.frameRate} totalFrames={frameTrack.trackItems.length} />
+          <TimelineTrack
+            track={frameTrack}
+            key={frameTrack.id}
+            timelineIndex={timelineIndex}
+            onClickItem={(trackItemIndex) => onClickItem(frameTrack, trackItemIndex)}
+            onClickLiveView={() => stopPlayback()}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/animator/Timeline/TimelineLiveView/TimelineLiveView.css
+++ b/src/renderer/components/animator/Timeline/TimelineLiveView/TimelineLiveView.css
@@ -2,7 +2,6 @@
   height: 100%;
   min-width: calc(var(--width-16) * 7);
   width: calc(var(--width-16) * 7);
-  margin-right: var(--width-16);
 }
 
 .timeline-live-view__button {

--- a/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.css
+++ b/src/renderer/components/animator/Timeline/TimelinePosition/TimelinePosition.css
@@ -12,7 +12,7 @@
   height: 100%;
   line-height: 1.2;
   overflow: hidden;
-  padding-left: calc(var(--width-16) * 4);
+  padding-left: var(--margin-100);
   width: 100%;
 }
 

--- a/src/renderer/components/animator/Timeline/TimelineTrack/TimelineTrack.css
+++ b/src/renderer/components/animator/Timeline/TimelineTrack/TimelineTrack.css
@@ -3,5 +3,6 @@
   display: flex;
   height: var(--height-800);
   width: max-content;
-  padding: var(--margin-100) 0;
+  padding: var(--margin-100);
+  gap: var(--margin-100);
 }

--- a/src/renderer/components/animator/Timeline/TimelineTrack/TimelineTrack.tsx
+++ b/src/renderer/components/animator/Timeline/TimelineTrack/TimelineTrack.tsx
@@ -11,7 +11,6 @@ import {
 } from "../../../../services/project/projectCalculator";
 import TimelineLiveViewButton from "../TimelineLiveView/TimelineLiveView";
 import TimelineTrackItem from "../TimelineTrackItem/TimelineTrackItem";
-import TimelineTrackLabel from "../TimelineTrackLabel/TimelineTrackLabel";
 import TimelineTrackNoItems from "../TimelineTrackNoItems/TimelineTrackNoItems";
 import "./TimelineTrack.css";
 
@@ -37,8 +36,6 @@ const TimelineTrack = ({
 
   return (
     <div className="timeline-track">
-      <TimelineTrackLabel fileType={track.fileType} />
-
       {track.trackItems.length > 0 ? (
         <>
           {track.trackItems.map((trackItem, i) => {

--- a/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.css
+++ b/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.css
@@ -31,3 +31,10 @@
 .timeline-track-item__cover:active {
   background-color: var(--ba-light-30);
 }
+
+.timetime-track-item__scroll-target {
+  position: absolute;
+  height: 100%;
+  width: calc(var(--margin-100) * 2 + 100%);
+  left: calc(var(--margin-100) * -1);
+}

--- a/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.css
+++ b/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.css
@@ -3,7 +3,6 @@
   height: 100%;
   min-width: calc(var(--width-16) * 7);
   width: calc(var(--width-16) * 7);
-  margin-right: var(--width-16);
 }
 
 .timeline-track-item__img {

--- a/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.tsx
+++ b/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.tsx
@@ -10,17 +10,17 @@ interface TimelineTrackItemProps {
 }
 
 const TimelineTrackItem = ({ title, dataUrl, highlighted, onClick }: TimelineTrackItemProps) => {
-  const trackItemRef = useRef<HTMLDivElement>(null);
+  const scrollTargetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (highlighted) {
       // Note: this is a non-standard webkit method
-      (trackItemRef.current as any)?.scrollIntoViewIfNeeded();
+      (scrollTargetRef.current as any)?.scrollIntoViewIfNeeded();
     }
   }, [highlighted]);
 
   return (
-    <div className="timeline-track-item" ref={trackItemRef} onClick={onClick} title={title}>
+    <div className="timeline-track-item" onClick={onClick} title={title}>
       <img
         className={classNames("timeline-track-item__img", {
           "timeline-track-item__img--highlighted": highlighted,
@@ -29,6 +29,7 @@ const TimelineTrackItem = ({ title, dataUrl, highlighted, onClick }: TimelineTra
         key={dataUrl}
       />
       <div className="timeline-track-item__cover"></div>
+      <div className="timetime-track-item__scroll-target" ref={scrollTargetRef}></div>
     </div>
   );
 };

--- a/src/renderer/components/animator/Timeline/TimelineTrackLabel/TimelineTrackLabel.css
+++ b/src/renderer/components/animator/Timeline/TimelineTrackLabel/TimelineTrackLabel.css
@@ -2,7 +2,7 @@
   align-items: center;
   color: var(--ba-light-mid);
   display: flex;
-  height: 100%;
+  height: var(--height-800);
   padding: var(--width-16);
   min-width: calc(var(--width-16) * 4);
   width: calc(var(--width-16) * 4);


### PR DESCRIPTION
* Keep timeline track labels in place when timeline scrolls. Resolves #395.
* Also when you select a frame in the timeline, the scrolling behaviour will now put some margin either side of the frame

![image](https://github.com/charlielee/boats-animator/assets/8095888/094bbccd-510f-40e2-9143-322586a151f2)
