### PR TITLE
Refactor capture provider

### DIFF
--- a/src/common/FileRef.ts
+++ b/src/common/FileRef.ts
@@ -19,11 +19,7 @@ export const makeFrameFileRef = (trackItemId: TrackItemId, location: string): Fi
   available: true,
 });
 
-export const getFileRefById = (fileRefs: FileRef[], trackItemId: TrackItemId): FileRef => {
-  const fileRef = fileRefs.find((fileRef) => fileRef.trackItemId === trackItemId);
-  if (fileRef !== undefined) {
-    return fileRef;
-  } else {
-    throw `No file ref with trackItemId ${trackItemId} found`;
-  }
-};
+export const getFileRefById = (
+  fileRefs: FileRef[],
+  trackItemId: TrackItemId
+): FileRef | undefined => fileRefs.find((fileRef) => fileRef.trackItemId === trackItemId);

--- a/src/common/project/Take.ts
+++ b/src/common/project/Take.ts
@@ -7,6 +7,5 @@ export interface Take {
   takeNumber: number;
   frameRate: FrameRate;
   holdFrames: FrameCount;
-  lastExportedFrameNumber: number;
   frameTrack: Track;
 }

--- a/src/common/project/TrackItem.ts
+++ b/src/common/project/TrackItem.ts
@@ -1,8 +1,9 @@
-import { FrameCount, TrackGroupId, TrackItemId } from "../Flavors";
+import { FrameCount, TimelineIndex, TrackGroupId, TrackItemId } from "../Flavors";
 
 export interface TrackItem {
   id: TrackItemId;
   length: FrameCount;
   filePath: string;
+  fileNumber: TimelineIndex;
   trackGroupId: TrackGroupId;
 }

--- a/src/common/testConstants.ts
+++ b/src/common/testConstants.ts
@@ -18,7 +18,6 @@ export const TAKE: Take = {
   takeNumber: 1,
   frameRate: 15,
   holdFrames: 1,
-  lastExportedFrameNumber: 0,
   frameTrack: {
     id: uuidv4(),
     fileType: FileRefType.FRAME,

--- a/src/renderer/components/animator/CaptureSidebarBlock/CaptureSidebarBlock.tsx
+++ b/src/renderer/components/animator/CaptureSidebarBlock/CaptureSidebarBlock.tsx
@@ -6,13 +6,14 @@ import InputGroup from "../../common/Input/InputGroup/InputGroup";
 import InputLabel from "../../common/Input/InputLabel/InputLabel";
 import InputSelect from "../../common/Input/InputSelect/InputSelect";
 import SidebarBlock from "../../common/SidebarBlock/SidebarBlock";
+import useDeviceList from "../../../hooks/useDeviceList";
 
 const CaptureSidebarBlock = (): JSX.Element => {
   const dispatch: ThunkDispatch<RootState, void, Action> = useDispatch();
-  const { deviceStatus, deviceList } = useSelector((state: RootState) => ({
+  const { deviceStatus } = useSelector((state: RootState) => ({
     deviceStatus: state.capture.deviceStatus,
-    deviceList: state.capture.deviceList,
   }));
+  const deviceList = useDeviceList();
 
   const buildCameraSourceOptions = () => ({
     "No camera selected": "#",
@@ -28,7 +29,7 @@ const CaptureSidebarBlock = (): JSX.Element => {
           options={buildCameraSourceOptions()}
           value={deviceStatus?.identifier?.deviceId ?? "#"}
           onChange={(deviceId) =>
-            dispatch(setCurrentDeviceFromId(deviceId === "#" ? undefined : deviceId))
+            dispatch(setCurrentDeviceFromId(deviceId === "#" ? undefined : deviceId, deviceList))
           }
         />
       </InputGroup>

--- a/src/renderer/components/animator/CaptureSidebarBlock/CaptureSidebarBlock.tsx
+++ b/src/renderer/components/animator/CaptureSidebarBlock/CaptureSidebarBlock.tsx
@@ -1,12 +1,13 @@
 import { Action, ThunkDispatch } from "@reduxjs/toolkit";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../../redux/store";
-import { setCurrentDeviceFromId } from "../../../redux/thunks";
 import InputGroup from "../../common/Input/InputGroup/InputGroup";
 import InputLabel from "../../common/Input/InputLabel/InputLabel";
 import InputSelect from "../../common/Input/InputSelect/InputSelect";
 import SidebarBlock from "../../common/SidebarBlock/SidebarBlock";
 import useDeviceList from "../../../hooks/useDeviceList";
+import { ImagingDeviceIdentifier } from "../../../services/imagingDevice/ImagingDevice";
+import { changeDevice, closeDevice } from "../../../redux/slices/captureSlice";
 
 const CaptureSidebarBlock = (): JSX.Element => {
   const dispatch: ThunkDispatch<RootState, void, Action> = useDispatch();
@@ -20,6 +21,17 @@ const CaptureSidebarBlock = (): JSX.Element => {
     ...Object.fromEntries(deviceList.map((identifier) => [identifier.name, identifier.deviceId])),
   });
 
+  const deviceIdToDeviceIdentifier = (deviceId: string): ImagingDeviceIdentifier => {
+    const identifier = deviceList.find((identifier) => identifier.deviceId === deviceId);
+    if (identifier === undefined) {
+      throw "Selected device not found in device list";
+    }
+    return identifier;
+  };
+
+  const getCurrentDeviceIdentifier = (deviceId: string) =>
+    deviceId === "#" ? undefined : deviceIdToDeviceIdentifier(deviceId);
+
   return (
     <SidebarBlock title="Capture">
       <InputGroup>
@@ -28,9 +40,10 @@ const CaptureSidebarBlock = (): JSX.Element => {
           id="camera-source-select"
           options={buildCameraSourceOptions()}
           value={deviceStatus?.identifier?.deviceId ?? "#"}
-          onChange={(deviceId) =>
-            dispatch(setCurrentDeviceFromId(deviceId === "#" ? undefined : deviceId, deviceList))
-          }
+          onChange={(deviceId) => {
+            const identifier = getCurrentDeviceIdentifier(deviceId);
+            dispatch(identifier ? changeDevice(identifier) : closeDevice());
+          }}
         />
       </InputGroup>
     </SidebarBlock>

--- a/src/renderer/components/animator/Preview/Preview.tsx
+++ b/src/renderer/components/animator/Preview/Preview.tsx
@@ -27,7 +27,7 @@ const Preview = ({ device, liveViewVisible, timelineIndex }: PreviewProps): JSX.
 
   const highlightedTrackItem = getHighlightedTrackItem(take.frameTrack, timelineIndex);
   const previewSrc = highlightedTrackItem
-    ? getFileRefById(fileRefs, highlightedTrackItem.id).location
+    ? getFileRefById(fileRefs, highlightedTrackItem.id)?.location
     : undefined;
 
   return (

--- a/src/renderer/components/animator/Timeline/TimelineTrack/TimelineTrack.tsx
+++ b/src/renderer/components/animator/Timeline/TimelineTrack/TimelineTrack.tsx
@@ -36,7 +36,7 @@ const TimelineTrack = ({
             return (
               <TimelineTrackItem
                 title={getTrackItemTitle(track, i)}
-                dataUrl={getFileRefById(fileRefs, trackItem.id).location}
+                dataUrl={getFileRefById(fileRefs, trackItem.id)?.location}
                 highlighted={highlightedTrackItem?.id === trackItem.id}
                 key={trackItem.id}
                 onClick={() => onClickItem(i)}

--- a/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.css
+++ b/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.css
@@ -3,6 +3,12 @@
   height: 100%;
   min-width: calc(var(--width-16) * 7);
   width: calc(var(--width-16) * 7);
+  border-radius: var(--margin-025);
+}
+
+.timeline-track-item--loading {
+  background-color: var(--ba-dark-mid-hover);
+  cursor: progress;
 }
 
 .timeline-track-item__img {

--- a/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.tsx
+++ b/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.tsx
@@ -1,10 +1,11 @@
 import classNames from "classnames";
 import { useCallback } from "react";
 import "./TimelineTrackItem.css";
+import { v4 as uuidv4 } from "uuid";
 
 interface TimelineTrackItemProps {
   title: string;
-  dataUrl: string;
+  dataUrl: string | undefined;
   highlighted: boolean;
   onClick: () => void;
 }
@@ -27,7 +28,7 @@ const TimelineTrackItem = ({ title, dataUrl, highlighted, onClick }: TimelineTra
           "timeline-track-item__img--highlighted": highlighted,
         })}
         src={dataUrl}
-        key={dataUrl}
+        key={dataUrl ?? uuidv4()}
       />
       <div className="timeline-track-item__cover"></div>
       <div className="timetime-track-item__scroll-target" ref={scrollTargetRef}></div>

--- a/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.tsx
+++ b/src/renderer/components/animator/Timeline/TimelineTrackItem/TimelineTrackItem.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import { useCallback } from "react";
 import "./TimelineTrackItem.css";
-import { v4 as uuidv4 } from "uuid";
 
 interface TimelineTrackItemProps {
   title: string;
@@ -22,14 +21,21 @@ const TimelineTrackItem = ({ title, dataUrl, highlighted, onClick }: TimelineTra
   );
 
   return (
-    <div className="timeline-track-item" onClick={onClick} title={title}>
-      <img
-        className={classNames("timeline-track-item__img", {
-          "timeline-track-item__img--highlighted": highlighted,
-        })}
-        src={dataUrl}
-        key={dataUrl ?? uuidv4()}
-      />
+    <div
+      className={classNames("timeline-track-item", {
+        "timeline-track-item--loading": dataUrl === undefined,
+      })}
+      onClick={onClick}
+      title={title}
+    >
+      {dataUrl !== undefined && (
+        <img
+          className={classNames("timeline-track-item__img", {
+            "timeline-track-item__img--highlighted": highlighted,
+          })}
+          src={dataUrl}
+        />
+      )}
       <div className="timeline-track-item__cover"></div>
       <div className="timetime-track-item__scroll-target" ref={scrollTargetRef}></div>
     </div>

--- a/src/renderer/components/common/AppListener/AppListener.tsx
+++ b/src/renderer/components/common/AppListener/AppListener.tsx
@@ -4,9 +4,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { PageRoute } from "../../../../common/PageRoute";
 import { RootState } from "../../../redux/store";
-import { fetchAndSetDeviceList, loadSavedPreferences, onRouteChange } from "../../../redux/thunks";
+import { loadSavedPreferences, onRouteChange } from "../../../redux/thunks";
 import { handleOnCloseButtonClick } from "../../../services/appListener/AppListenerService";
-import { onDeviceChange } from "../../../services/imagingDevice/ImagingDevice";
 import * as rLogger from "../../../services/rLogger/rLogger";
 
 const AppListeners = (): JSX.Element => {
@@ -18,11 +17,6 @@ const AppListeners = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(loadSavedPreferences());
-
-    dispatch(fetchAndSetDeviceList());
-    onDeviceChange(() => {
-      dispatch(fetchAndSetDeviceList());
-    });
   }, [dispatch]);
 
   // Handle pressing the close button

--- a/src/renderer/hooks/useDeviceList.ts
+++ b/src/renderer/hooks/useDeviceList.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import {
+  ImagingDeviceIdentifier,
+  addDeviceChangeListeners,
+  listDevices,
+  removeDeviceChangeListeners,
+} from "../services/imagingDevice/ImagingDevice";
+
+const useDeviceList = () => {
+  const [deviceList, setDeviceList] = useState<ImagingDeviceIdentifier[]>([]);
+
+  const fetchDeviceList = async () => {
+    setDeviceList(await listDevices());
+  };
+
+  useEffect(() => {
+    fetchDeviceList();
+    addDeviceChangeListeners(fetchDeviceList);
+
+    return () => {
+      removeDeviceChangeListeners(fetchDeviceList);
+    };
+  }, []);
+
+  return deviceList;
+};
+
+export default useDeviceList;

--- a/src/renderer/redux/slices/captureSlice.ts
+++ b/src/renderer/redux/slices/captureSlice.ts
@@ -6,12 +6,10 @@ import {
 
 interface CaptureState {
   deviceStatus: ImagingDeviceStatus | undefined;
-  deviceList: ImagingDeviceIdentifier[];
 }
 
 const initialState: CaptureState = {
   deviceStatus: undefined,
-  deviceList: [],
 };
 
 const captureSlice = createSlice({
@@ -37,14 +35,9 @@ const captureSlice = createSlice({
     changeDevice: (state, action: PayloadAction<ImagingDeviceIdentifier>) => {
       state.deviceStatus = { identifier: action.payload, open: true };
     },
-
-    setDeviceList: (state, action: PayloadAction<ImagingDeviceIdentifier[]>) => {
-      state.deviceList = action.payload;
-    },
   },
 });
 
-export const { reopenDevice, pauseDevice, closeDevice, changeDevice, setDeviceList } =
-  captureSlice.actions;
+export const { reopenDevice, pauseDevice, closeDevice, changeDevice } = captureSlice.actions;
 
 export const captureReducer = captureSlice.reducer;

--- a/src/renderer/redux/slices/projectSlice.ts
+++ b/src/renderer/redux/slices/projectSlice.ts
@@ -36,12 +36,6 @@ const projectSlice = createSlice({
       state.take?.frameTrack.trackItems.push(action.payload);
     },
 
-    incrementExportedFrameNumber: (state) => {
-      if (state.take) {
-        state.take.lastExportedFrameNumber += 1;
-      }
-    },
-
     setPlaybackSpeed: (state, action: PayloadAction<number>) => {
       state.playbackSpeed = action.payload;
     },
@@ -60,7 +54,6 @@ export const {
   addProject,
   updateProject,
   addFrameTrackItem,
-  incrementExportedFrameNumber,
   setPlaybackSpeed,
   addFileRef,
   addTake,

--- a/src/renderer/redux/thunks.ts
+++ b/src/renderer/redux/thunks.ts
@@ -1,22 +1,8 @@
 import { Action, ThunkDispatch } from "@reduxjs/toolkit";
 import { PageRoute } from "../../common/PageRoute";
 import { editUserPreferences, setCameraAccess, startLoading, stopLoading } from "./slices/appSlice";
-import { changeDevice, closeDevice, pauseDevice, reopenDevice } from "./slices/captureSlice";
+import { pauseDevice, reopenDevice } from "./slices/captureSlice";
 import { RootState } from "./store";
-import { ImagingDeviceIdentifier } from "../services/imagingDevice/ImagingDevice";
-
-export const setCurrentDeviceFromId = (
-  deviceId: string | undefined,
-  deviceList: ImagingDeviceIdentifier[]
-) => {
-  return (dispatch: ThunkDispatch<RootState, void, Action>) => {
-    const identifier = deviceList.find((identifier) => identifier.deviceId === deviceId);
-
-    dispatch(identifier ? changeDevice(identifier) : closeDevice());
-
-    return identifier;
-  };
-};
 
 export const changeWorkingDirectory = (workingDirectory?: string) => {
   return (dispatch: ThunkDispatch<RootState, void, Action>) => {

--- a/src/renderer/redux/thunks.ts
+++ b/src/renderer/redux/thunks.ts
@@ -1,28 +1,15 @@
 import { Action, ThunkDispatch } from "@reduxjs/toolkit";
 import { PageRoute } from "../../common/PageRoute";
-import { listDevices } from "../services/imagingDevice/ImagingDevice";
 import { editUserPreferences, setCameraAccess, startLoading, stopLoading } from "./slices/appSlice";
-import {
-  closeDevice,
-  pauseDevice,
-  reopenDevice,
-  changeDevice,
-  setDeviceList,
-} from "./slices/captureSlice";
+import { changeDevice, closeDevice, pauseDevice, reopenDevice } from "./slices/captureSlice";
 import { RootState } from "./store";
+import { ImagingDeviceIdentifier } from "../services/imagingDevice/ImagingDevice";
 
-export const fetchAndSetDeviceList = () => {
+export const setCurrentDeviceFromId = (
+  deviceId: string | undefined,
+  deviceList: ImagingDeviceIdentifier[]
+) => {
   return (dispatch: ThunkDispatch<RootState, void, Action>) => {
-    return (async () => {
-      const connectedDevices = await listDevices();
-      dispatch(setDeviceList(connectedDevices));
-    })();
-  };
-};
-
-export const setCurrentDeviceFromId = (deviceId?: string) => {
-  return (dispatch: ThunkDispatch<RootState, void, Action>, getState: () => RootState) => {
-    const { deviceList } = getState().capture;
     const identifier = deviceList.find((identifier) => identifier.deviceId === deviceId);
 
     dispatch(identifier ? changeDevice(identifier) : closeDevice());

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -24,11 +24,6 @@ export interface ImagingDevice {
   takePhoto(): Promise<Blob>;
 }
 
-const IMAGING_DEVICE_CHANGE_EVENT_NAME = "imaging-device-change";
-
-const dispatchDeviceChangeEvent = () =>
-  document.dispatchEvent(new CustomEvent(IMAGING_DEVICE_CHANGE_EVENT_NAME));
-
 export const listDevices = async (): Promise<ImagingDeviceIdentifier[]> => {
   rLogger.info("imagingDevice.listDevices.start");
   const webMediaDevices = await WebMediaDevice.listDevices();
@@ -38,9 +33,12 @@ export const listDevices = async (): Promise<ImagingDeviceIdentifier[]> => {
   return allDevices;
 };
 
-export const onDeviceChange = (callback: () => void): void => {
-  WebMediaDevice.onDeviceChange(dispatchDeviceChangeEvent);
-  document.addEventListener(IMAGING_DEVICE_CHANGE_EVENT_NAME, callback);
+export const addDeviceChangeListeners = (listener: () => void): void => {
+  WebMediaDevice.addDeviceChangeListener(listener);
+};
+
+export const removeDeviceChangeListeners = (listener: () => void): void => {
+  WebMediaDevice.removeDeviceChangeListener(listener);
 };
 
 export const deviceIdentifierToDevice = (identifier: ImagingDeviceIdentifier): ImagingDevice => {

--- a/src/renderer/services/imagingDevice/WebMediaDevice.ts
+++ b/src/renderer/services/imagingDevice/WebMediaDevice.ts
@@ -103,8 +103,12 @@ class WebMediaDevice implements ImagingDevice {
       }));
   }
 
-  static onDeviceChange(callback: () => void): void {
-    navigator.mediaDevices.addEventListener("devicechange", callback);
+  static addDeviceChangeListener(listener: () => void): void {
+    navigator.mediaDevices.addEventListener("devicechange", listener);
+  }
+
+  static removeDeviceChangeListener(listener: () => void): void {
+    navigator.mediaDevices.removeEventListener("devicechange", listener);
   }
 }
 

--- a/src/renderer/services/project/projectBuilder.test.ts
+++ b/src/renderer/services/project/projectBuilder.test.ts
@@ -134,20 +134,11 @@ describe("makeTakeDirectoryPath", () => {
 });
 
 describe("makeFrameFilePath", () => {
-  it("should make frame file path when frame name supplied", () => {
+  it("should make expected frame file path", () => {
     const fileName = "cheese";
 
     expect(makeFrameFilePath(PROJECT, TAKE, fileName)).toEqual(
       `${projectDirectory}/BA_001_01/ba_001_01_frame_cheese.jpg`
-    );
-  });
-
-  it("should make frame file path when frame name not supplied", () => {
-    const take = TAKE;
-    take.lastExportedFrameNumber = 3;
-
-    expect(makeFrameFilePath(PROJECT, take)).toEqual(
-      `${projectDirectory}/BA_001_01/ba_001_01_frame_00004.jpg`
     );
   });
 });

--- a/src/renderer/services/project/projectBuilder.test.ts
+++ b/src/renderer/services/project/projectBuilder.test.ts
@@ -97,25 +97,27 @@ describe("makeTake", () => {
 });
 
 describe("makeFrameTrackItem", () => {
-  it("should make frame track item with no Track Group ID supplied", () => {
-    const filePath = "/frame.jpg";
+  const filePath = "/frame.jpg";
+  const fileNumber = 0;
 
-    expect(makeFrameTrackItem(filePath)).toStrictEqual({
+  it("should make frame track item with no Track Group ID supplied", () => {
+    expect(makeFrameTrackItem(filePath, fileNumber)).toStrictEqual({
       filePath,
       id: expect.any(String),
       length: 1,
+      fileNumber,
       trackGroupId: expect.any(String),
     });
   });
 
   it("should make frame track item with Track Group ID supplied", () => {
-    const filePath = "/frame.jpg";
     const trackGroupId = TRACK_GROUP_ID;
 
-    expect(makeFrameTrackItem(filePath, trackGroupId)).toStrictEqual({
+    expect(makeFrameTrackItem(filePath, fileNumber, trackGroupId)).toStrictEqual({
       filePath,
       id: expect.any(String),
       length: 1,
+      fileNumber,
       trackGroupId,
     });
   });

--- a/src/renderer/services/project/projectBuilder.ts
+++ b/src/renderer/services/project/projectBuilder.ts
@@ -54,10 +54,15 @@ export const makeTake = ({ shotNumber, takeNumber, frameRate }: ProjectBuilderOp
   },
 });
 
-export const makeFrameTrackItem = (filePath: string, trackGroupId?: TrackGroupId): TrackItem => ({
+export const makeFrameTrackItem = (
+  filePath: string,
+  fileNumber: number,
+  trackGroupId?: TrackGroupId
+): TrackItem => ({
   id: uuidv4(),
   length: 1,
   filePath,
+  fileNumber,
   trackGroupId: trackGroupId ?? uuidv4(),
 });
 

--- a/src/renderer/services/project/projectBuilder.ts
+++ b/src/renderer/services/project/projectBuilder.ts
@@ -47,7 +47,6 @@ export const makeTake = ({ shotNumber, takeNumber, frameRate }: ProjectBuilderOp
   takeNumber,
   frameRate,
   holdFrames: 1,
-  lastExportedFrameNumber: 0,
   frameTrack: {
     id: uuidv4(),
     fileType: FileRefType.FRAME,
@@ -74,7 +73,7 @@ export const makeTakeDirectoryPath = (project: Project, take: Take) =>
     `BA_${zeroPad(take.shotNumber, 3)}_${zeroPad(take.takeNumber, 2)}`
   );
 
-export const makeFrameFilePath = (project: Project, take: Take, frameName?: string): string =>
+export const makeFrameFilePath = (project: Project, take: Take, frameName: string): string =>
   window.preload.joinPath(
     makeTakeDirectoryPath(project, take),
     [
@@ -82,6 +81,6 @@ export const makeFrameFilePath = (project: Project, take: Take, frameName?: stri
       zeroPad(take.shotNumber, 3),
       zeroPad(take.takeNumber, 2),
       "frame",
-      `${frameName ?? zeroPad(take.lastExportedFrameNumber + 1, 5)}.jpg`,
+      `${frameName}.jpg`,
     ].join("_")
   );

--- a/src/renderer/services/project/projectCalculator.test.ts
+++ b/src/renderer/services/project/projectCalculator.test.ts
@@ -1,0 +1,47 @@
+import { FileRefType } from "../../../common/FileRef";
+import { Track } from "../../../common/project/Track";
+import { getNextFileNumber } from "./projectCalculator";
+
+describe("getNextFileNumber", () => {
+  it("should get next file number for track with no items", () => {
+    const track: Track = {
+      id: "trackId",
+      fileType: FileRefType.FRAME,
+      trackItems: [],
+    };
+
+    expect(getNextFileNumber(track)).toBe(1);
+  });
+
+  it("should get next file number for track with items", () => {
+    const track1: Track = {
+      id: "trackId",
+      fileType: FileRefType.FRAME,
+      trackItems: [
+        {
+          id: "trackItemId",
+          length: 1,
+          filePath: "somewhere.jpg",
+          fileNumber: 1,
+          trackGroupId: "trackGroupId",
+        },
+      ],
+    };
+    const track2: Track = {
+      id: "trackId",
+      fileType: FileRefType.FRAME,
+      trackItems: [
+        {
+          id: "trackItemId",
+          length: 1,
+          filePath: "somewhere.jpg",
+          fileNumber: 7,
+          trackGroupId: "trackGroupId",
+        },
+      ],
+    };
+
+    expect(getNextFileNumber(track1)).toBe(2);
+    expect(getNextFileNumber(track2)).toBe(8);
+  });
+});

--- a/src/renderer/services/project/projectCalculator.ts
+++ b/src/renderer/services/project/projectCalculator.ts
@@ -28,3 +28,7 @@ export const getTrackItemTitle = (track: Track, trackItemIndex: number) =>
   track.fileType === FileRefType.FRAME
     ? `Frame ${getTrackItemStartPosition(track, trackItemIndex) + 1}`
     : track.trackItems[trackItemIndex].filePath;
+
+const getLastFileNumberInTrack = (track: Track): number => track.trackItems.at(-1)?.fileNumber ?? 0;
+
+export const getNextFileNumber = (track: Track): number => getLastFileNumberInTrack(track) + 1;


### PR DESCRIPTION
Refactors the capture provider to be a lot simpler and less dodgy:

* The device list is now a hook directly listening to the `devicechange` JS event listener
* Fixes #450
* Fixes #391 by adding file numbers to track items. These should be recalculated when "conform take" is reimplemented.