### PR TITLE
Project file improvements

### DIFF
--- a/src/common/Flavors.ts
+++ b/src/common/Flavors.ts
@@ -10,7 +10,7 @@ export type FrameRate = Flavor<number, "FrameRate">;
 export type TimelineIndex = Flavor<number, "TimelineIndex">;
 type NumberFlavor = FrameCount | FrameRate | TimelineIndex;
 
-export type IsoDateString = Flavor<string, "IsoDateString">;
+export type IsoDateTimeString = Flavor<string, "IsoDateTimeString">;
 
 export type PersistedDirectoryId = Flavor<string, "PersistedDirectoryId">;
 export type FileInfoId = Flavor<string, "FileInfoId">;
@@ -21,7 +21,7 @@ export type TrackItemId = Flavor<string, "TrackItemId">;
 export type TrackGroupId = Flavor<string, "TrackGroupId">;
 
 type StringFlavor =
-  | IsoDateString
+  | IsoDateTimeString
   | PersistedDirectoryId
   | FileInfoId
   | TakeId

--- a/src/common/Flavors.ts
+++ b/src/common/Flavors.ts
@@ -10,6 +10,8 @@ export type FrameRate = Flavor<number, "FrameRate">;
 export type TimelineIndex = Flavor<number, "TimelineIndex">;
 type NumberFlavor = FrameCount | FrameRate | TimelineIndex;
 
+export type IsoDateString = Flavor<string, "IsoDateString">;
+
 export type PersistedDirectoryId = Flavor<string, "PersistedDirectoryId">;
 export type FileInfoId = Flavor<string, "FileInfoId">;
 
@@ -19,6 +21,7 @@ export type TrackItemId = Flavor<string, "TrackItemId">;
 export type TrackGroupId = Flavor<string, "TrackGroupId">;
 
 type StringFlavor =
+  | IsoDateString
   | PersistedDirectoryId
   | FileInfoId
   | TakeId

--- a/src/common/project/Project.ts
+++ b/src/common/project/Project.ts
@@ -2,7 +2,7 @@ import { IsoDateTimeString } from "../Flavors";
 
 export interface Project {
   name: string;
-  fileName: string;
+  directoryName: string;
   projectFrameRate: number;
   lastSaved: IsoDateTimeString;
 }

--- a/src/common/project/Project.ts
+++ b/src/common/project/Project.ts
@@ -1,6 +1,8 @@
+import { IsoDateTimeString } from "../Flavors";
+
 export interface Project {
   name: string;
   fileName: string;
   projectFrameRate: number;
-  fileLastSavedToDisk?: Date;
+  lastSaved: IsoDateTimeString;
 }

--- a/src/common/project/Take.ts
+++ b/src/common/project/Take.ts
@@ -1,4 +1,4 @@
-import { FrameCount, FrameRate, TakeId } from "../Flavors";
+import { FrameCount, FrameRate, IsoDateString, TakeId } from "../Flavors";
 import { Track } from "./Track";
 
 export interface Take {
@@ -8,4 +8,5 @@ export interface Take {
   frameRate: FrameRate;
   holdFrames: FrameCount;
   frameTrack: Track;
+  lastSaved: IsoDateString;
 }

--- a/src/common/project/Take.ts
+++ b/src/common/project/Take.ts
@@ -1,4 +1,4 @@
-import { FrameCount, FrameRate, IsoDateString, TakeId } from "../Flavors";
+import { FrameCount, FrameRate, IsoDateTimeString, TakeId } from "../Flavors";
 import { Track } from "./Track";
 
 export interface Take {
@@ -8,5 +8,5 @@ export interface Take {
   frameRate: FrameRate;
   holdFrames: FrameCount;
   frameTrack: Track;
-  lastSaved: IsoDateString;
+  lastSaved: IsoDateTimeString;
 }

--- a/src/common/project/TrackItem.ts
+++ b/src/common/project/TrackItem.ts
@@ -3,7 +3,7 @@ import { FrameCount, TimelineIndex, TrackGroupId, TrackItemId } from "../Flavors
 export interface TrackItem {
   id: TrackItemId;
   length: FrameCount;
-  filePath: string;
+  fileName: string;
   fileNumber: TimelineIndex;
   trackGroupId: TrackGroupId;
 }

--- a/src/common/testConstants.ts
+++ b/src/common/testConstants.ts
@@ -3,6 +3,7 @@ import { FileInfoType } from "../renderer/context/FileManagerContext/FileInfo";
 import { Project } from "./project/Project";
 import { Take } from "./project/Take";
 import { DEFAULT_PROJECT_FRAME_RATE } from "./utils";
+import { IsoDateTimeString } from "./Flavors";
 
 export const PROJECT_NAME = "My Test Movie";
 export const PROJECT_FILE_NAME = "My-Test-Movie";
@@ -28,3 +29,6 @@ export const TAKE: Take = {
 };
 
 export const TRACK_GROUP_ID = "81d57cf4-af96-4b0c-b1ad-3664ba767be6";
+
+export const MOCK_ISO_DATE_TIME_STRING: IsoDateTimeString = "2024-01-01T00:00:00.000Z";
+export const MOCK_DATE_TIME = new Date(MOCK_ISO_DATE_TIME_STRING);

--- a/src/common/testConstants.ts
+++ b/src/common/testConstants.ts
@@ -2,14 +2,14 @@ import { v4 as uuidv4 } from "uuid";
 import { FileInfoType } from "../renderer/context/FileManagerContext/FileInfo";
 import { Project } from "./project/Project";
 import { Take } from "./project/Take";
-import { DEFAULT_PROJECT_FRAME_RATE } from "./utils";
+import { DEFAULT_PROJECT_FRAME_RATE, PROJECT_DIRECTORY_EXTENSION } from "./utils";
 import { IsoDateTimeString } from "./Flavors";
 
 export const PROJECT_NAME = "My Test Movie";
-export const PROJECT_FILE_NAME = "My-Test-Movie";
+export const PROJECT_DIRECTORY_NAME = `My-Test-Movie.${PROJECT_DIRECTORY_EXTENSION}`;
 export const PROJECT: Project = {
   name: PROJECT_NAME,
-  fileName: PROJECT_FILE_NAME,
+  directoryName: PROJECT_DIRECTORY_NAME,
   projectFrameRate: DEFAULT_PROJECT_FRAME_RATE,
   lastSaved: new Date("2024-01-01").toISOString(),
 };

--- a/src/common/testConstants.ts
+++ b/src/common/testConstants.ts
@@ -10,6 +10,7 @@ export const PROJECT: Project = {
   name: PROJECT_NAME,
   fileName: PROJECT_FILE_NAME,
   projectFrameRate: DEFAULT_PROJECT_FRAME_RATE,
+  lastSaved: new Date("2024-01-01").toISOString(),
 };
 
 export const TAKE: Take = {

--- a/src/common/testConstants.ts
+++ b/src/common/testConstants.ts
@@ -14,6 +14,7 @@ export const PROJECT: Project = {
 
 export const TAKE: Take = {
   id: uuidv4(),
+  lastSaved: new Date("2024-01-01").toISOString(),
   shotNumber: 1,
   takeNumber: 1,
   frameRate: 15,

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -21,5 +21,6 @@ export const PLAYBACK_SPEEDS = {
 export const PROJECT_DIRECTORY_EXTENSION = "boatsfiles";
 export const PROJECT_INFO_FILE_NAME = "project.boatsinfo";
 export const DEFAULT_PROJECT_NAME = "Untitled Movie";
-export const DEFAULT_PROJECT_NAME_FORMATTED = `Untitled-Movie`;
+export const DEFAULT_PROJECT_NAME_FORMATTED = "Untitled-Movie";
+export const DEFAULT_PROJECT_DIRECTORY_NAME = `Untitled-Movie.${PROJECT_DIRECTORY_EXTENSION}`;
 export const DEFAULT_PROJECT_FRAME_RATE = 15;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -21,5 +21,5 @@ export const PLAYBACK_SPEEDS = {
 export const PROJECT_DIRECTORY_EXTENSION = "boatsfiles";
 export const PROJECT_INFO_FILE_NAME = "project.boatsinfo";
 export const DEFAULT_PROJECT_NAME = "Untitled Movie";
-export const DEFAULT_PROJECT_FILE_NAME = "Untitled-Movie";
+export const DEFAULT_PROJECT_NAME_FORMATTED = `Untitled-Movie`;
 export const DEFAULT_PROJECT_FRAME_RATE = 15;

--- a/src/main/services/devToolsExtensions/DevToolsExtensions.ts
+++ b/src/main/services/devToolsExtensions/DevToolsExtensions.ts
@@ -1,4 +1,4 @@
-import { session } from "electron";
+import { session, app } from "electron";
 import fastGlob from "fast-glob";
 import logger from "../logger/Logger";
 
@@ -6,8 +6,8 @@ export const REACT_DEV_TOOLS_ID = "fmkadmapgofadopljbjfkapdkoienihi";
 export const REDUX_DEV_TOOLS_ID = "lmhkpmbekcpmknklioeibfkpmmfibljd";
 
 const WINDOWS_DIR = `${process.env.LOCALAPPDATA}\\Google\\Chrome\\User Data\\Default\\Extensions`;
-const MAC_DIR = "~/Library/Application Support/Google/Chrome/Default/Extensions";
-const LINUX_DIR = "~/.config/google-chrome/Default/Extensions";
+const MAC_DIR = `${app.getPath("home")}/Library/Application Support/Google/Chrome/Default/Extensions`;
+const LINUX_DIR = `${app.getPath("home")}/.config/google-chrome/Default/Extensions`;
 
 const getExtensionDirectory = () => {
   switch (process.platform) {

--- a/src/renderer/components/animator/TitleToolbar/TitleToolbar.tsx
+++ b/src/renderer/components/animator/TitleToolbar/TitleToolbar.tsx
@@ -1,6 +1,6 @@
 import { PageRoute } from "../../../../common/PageRoute";
 import { Take } from "../../../../common/project/Take";
-import { zeroPad } from "../../../../common/utils";
+import { DEFAULT_PROJECT_NAME, zeroPad } from "../../../../common/utils";
 import useProjectAndTake from "../../../hooks/useProjectAndTake";
 import { getTrackLength } from "../../../services/project/projectCalculator";
 import Button from "../../common/Button/Button";
@@ -20,7 +20,7 @@ const TitleToolbar = (): JSX.Element => {
     <Toolbar className="title-toolbar">
       <ToolbarItem stretch align={ToolbarItemAlign.LEFT}>
         <Button
-          label={project.name}
+          label={project.name === "" ? DEFAULT_PROJECT_NAME : project.name}
           title="Manage project"
           onClick={PageRoute.STARTUP}
           color={ButtonColor.TRANSPARENT}

--- a/src/renderer/components/common/App/App.tsx
+++ b/src/renderer/components/common/App/App.tsx
@@ -22,13 +22,11 @@ const App = (): JSX.Element => {
 
         <FileManagerContextProvider>
           <PersistedDirectoriesContextProvider>
-            <ProjectFilesContextProvider>
-              <Routes>
-                <Route index element={<Navigate to={PageRoute.STARTUP} />} />
-                {startupRoutes}
-                {animatorRoutes}
-              </Routes>
-            </ProjectFilesContextProvider>
+            <Routes>
+              <Route index element={<Navigate to={PageRoute.STARTUP} />} />
+              {startupRoutes}
+              {animatorRoutes}
+            </Routes>
           </PersistedDirectoriesContextProvider>
         </FileManagerContextProvider>
       </AppErrorBoundary>

--- a/src/renderer/components/common/App/useAnimatorRoutesAndProviders.tsx
+++ b/src/renderer/components/common/App/useAnimatorRoutesAndProviders.tsx
@@ -9,6 +9,7 @@ import { DeleteFrameModal } from "../../modals/DeleteFrameModal/DeleteFrameModal
 import ExportVideoModal from "../../modals/ExportVideoModal/ExportVideoModal";
 import PreferencesModal from "../../modals/PreferencesModal/PreferencesModal";
 import { useEffect } from "react";
+import { ProjectFilesContextProvider } from "../../../context/ProjectFilesContext.tsx/ProjectFilesContextProvider";
 
 export const useAnimatorRoutesAndProviders = () => {
   const project = useSelector((state: RootState) => state.project.project);
@@ -30,16 +31,18 @@ export const useAnimatorRoutesAndProviders = () => {
     <Route
       path={PageRoute.ANIMATOR}
       element={
-        <CaptureContextProvider>
-          <PlaybackContextProvider
-            take={take}
-            shortPlayLength={shortPlayLength}
-            playbackSpeed={playbackSpeed}
-          >
-            <Outlet />
-            <Animator />
-          </PlaybackContextProvider>
-        </CaptureContextProvider>
+        <ProjectFilesContextProvider>
+          <CaptureContextProvider>
+            <PlaybackContextProvider
+              take={take}
+              shortPlayLength={shortPlayLength}
+              playbackSpeed={playbackSpeed}
+            >
+              <Outlet />
+              <Animator />
+            </PlaybackContextProvider>
+          </CaptureContextProvider>
+        </ProjectFilesContextProvider>
       }
     >
       <Route path={PageRoute.ANIMATOR_DELETE_FRAME} element={<DeleteFrameModal />} />

--- a/src/renderer/components/modals/ExportVideoModal/ExportVideoModalOptions/ExportVideoModalOptions.tsx
+++ b/src/renderer/components/modals/ExportVideoModal/ExportVideoModalOptions/ExportVideoModalOptions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { PageRoute } from "../../../../../common/PageRoute";
 import useProjectAndTake from "../../../../hooks/useProjectAndTake";
-import { makeFrameFilePath } from "../../../../services/project/projectBuilder";
+import { makeFrameFileName } from "../../../../services/project/projectBuilder";
 import { getTrackLength } from "../../../../services/project/projectCalculator";
 import Button from "../../../common/Button/Button";
 import { ButtonColor } from "../../../common/Button/ButtonColor";
@@ -59,7 +59,7 @@ const ExportVideoModalOptions = ({
     );
     onVideoFilePathChange(videoFilePath);
 
-    const framePath = makeFrameFilePath(take, "%05d");
+    const framePath = makeFrameFileName(take, parseInt("%05d this will be broken"));
     const totalFrames = getTrackLength(take.frameTrack);
 
     setFFmpegArguments(

--- a/src/renderer/components/modals/NewProjectModal/NewProjectModal.tsx
+++ b/src/renderer/components/modals/NewProjectModal/NewProjectModal.tsx
@@ -4,14 +4,22 @@ import { useContext, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { PageRoute } from "../../../../common/PageRoute";
-import { DEFAULT_PROJECT_FRAME_RATE, PROJECT_DIRECTORY_EXTENSION } from "../../../../common/utils";
+import {
+  DEFAULT_PROJECT_FRAME_RATE,
+  DEFAULT_PROJECT_NAME,
+  PROJECT_DIRECTORY_EXTENSION,
+} from "../../../../common/utils";
 import { PersistedDirectoriesContext } from "../../../context/PersistedDirectoriesContext/PersistedDirectoriesContext";
 import { ProjectDirectoryIsInsideAnotherProjectError } from "../../../context/PersistedDirectoriesContext/PersistedDirectoriesErrors";
 import useWorkingDirectory from "../../../hooks/useWorkingDirectory";
 import { addProject, addTake } from "../../../redux/slices/projectSlice";
 import { RootState } from "../../../redux/store";
 import { CreateDirectoryAlreadyExistsError } from "../../../context/FileManagerContext/FileErrors";
-import { formatProjectName, makeProject, makeTake } from "../../../services/project/projectBuilder";
+import {
+  makeProject,
+  makeTake,
+  makeUniqueProjectDirectoryNameIfRequired,
+} from "../../../services/project/projectBuilder";
 import IconName from "../../common/Icon/IconName";
 import { SemanticColor } from "../../ui/Theme/SemanticColor";
 import { UiButton } from "../../ui/UiButton/UiButton";
@@ -21,6 +29,7 @@ import { UiTextInput } from "../../ui/UiTextInput/UiTextInput";
 import { UiNumberInput } from "../../ui/UiNumberInput/UiNumberInput";
 import { UiAlert } from "../../ui/UiAlert/UiAlert";
 import * as rLogger from "../../../services/rLogger/rLogger";
+import { Project } from "../../../../common/project/Project";
 
 export const NewProjectModal = () => {
   const dispatch: ThunkDispatch<RootState, void, Action> = useDispatch();
@@ -56,7 +65,10 @@ export const NewProjectModal = () => {
 
   const onSubmitNewProject = async () => {
     clearFormErrors();
-    const formattedProject = { ...project, name: formatProjectName(project.name) };
+    const formattedProject: Project = {
+      ...project,
+      directoryName: makeUniqueProjectDirectoryNameIfRequired(project.directoryName),
+    };
 
     try {
       const projectDirectoryEntry = await addProjectDirectory!(formattedProject);
@@ -98,7 +110,7 @@ export const NewProjectModal = () => {
         <UiTextInput
           label="Project Name"
           value={project.name}
-          placeholder="Untitled Movie"
+          placeholder={DEFAULT_PROJECT_NAME}
           error={projectNameError}
           onChange={onRenameProject}
         />

--- a/src/renderer/components/modals/NewProjectModal/NewProjectModal.tsx
+++ b/src/renderer/components/modals/NewProjectModal/NewProjectModal.tsx
@@ -11,12 +11,7 @@ import useWorkingDirectory from "../../../hooks/useWorkingDirectory";
 import { addProject, addTake } from "../../../redux/slices/projectSlice";
 import { RootState } from "../../../redux/store";
 import { CreateDirectoryAlreadyExistsError } from "../../../context/FileManagerContext/FileErrors";
-import {
-  formatProjectName,
-  makeProject,
-  makeProjectDirectoryName,
-  makeTake,
-} from "../../../services/project/projectBuilder";
+import { formatProjectName, makeProject, makeTake } from "../../../services/project/projectBuilder";
 import IconName from "../../common/Icon/IconName";
 import { SemanticColor } from "../../ui/Theme/SemanticColor";
 import { UiButton } from "../../ui/UiButton/UiButton";
@@ -77,7 +72,7 @@ export const NewProjectModal = () => {
       navigate(PageRoute.ANIMATOR);
     } catch (e) {
       if (e instanceof CreateDirectoryAlreadyExistsError) {
-        rLogger.warn("newProjectModal.projectAlreadyExists", project.fileName);
+        rLogger.warn("newProjectModal.projectAlreadyExists", project.directoryName);
         return setProjectNameError(
           "Unable to create project as a project already exists with this name. Please rename your project and try again."
         );
@@ -112,7 +107,7 @@ export const NewProjectModal = () => {
           label="Project files will be saved to..."
           value={
             workingDirectory
-              ? `./${workingDirectory.friendlyName}/${makeProjectDirectoryName(project)}`
+              ? `./${workingDirectory.friendlyName}/${project.directoryName}`
               : undefined
           }
           placeholder="No folder selected"

--- a/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
+++ b/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
@@ -37,7 +37,16 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
   const takePhoto = () => {
     rLogger.info("captureContextProvider.takePhoto");
 
+    if (device === undefined) {
+      rLogger.info(
+        "captureContextProvider.takePhoto.noDevice",
+        "Nothing captured as no device selected"
+      );
+      return;
+    }
+
     if (playCaptureSound) {
+      rLogger.info("captureContextProvider.takePhoto.playCaptureSound");
       const audio = new Audio(cameraSound);
       audio.play();
     }
@@ -49,18 +58,18 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     dispatch(addFrameTrackItem(trackItem));
 
     // Intentionally fire async method without await
-    processPhoto(trackItem);
+    _processPhoto(trackItem);
   };
 
-  const processPhoto = async (trackItem: TrackItem) => {
-    if (!device) {
-      return;
+  const _processPhoto = async (trackItem: TrackItem) => {
+    if (device === undefined) {
+      throw "No device was found";
     }
     const imageData = await device.takePhoto();
     await saveTrackItemToDisk!(take, trackItem, imageData);
   };
 
-  const onChangeDevice = useCallback(async () => {
+  const _onChangeDevice = useCallback(async () => {
     rLogger.info("captureContextProvider.onChangeDevice", JSON.stringify(deviceStatus));
     const identifier = deviceStatus?.identifier;
     const newDevice = identifier ? deviceIdentifierToDevice(identifier) : undefined;
@@ -74,7 +83,7 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     setDevice(newDevice);
   }, [deviceStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const onDeviceListChange = useCallback(() => {
+  const _onDeviceListChange = useCallback(() => {
     if (
       deviceStatus &&
       !deviceList.find((identifier) => identifier.deviceId === deviceStatus.identifier.deviceId)
@@ -85,12 +94,12 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
   }, [deviceList, deviceStatus, dispatch]);
 
   useEffect(() => {
-    onChangeDevice();
-  }, [onChangeDevice, deviceStatus]);
+    _onChangeDevice();
+  }, [_onChangeDevice, deviceStatus]);
 
   useEffect(() => {
-    onDeviceListChange();
-  }, [onDeviceListChange, deviceList]);
+    _onDeviceListChange();
+  }, [_onDeviceListChange, deviceList]);
 
   return (
     <CaptureContext.Provider

--- a/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
+++ b/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
@@ -2,7 +2,6 @@ import { Action, ThunkDispatch } from "@reduxjs/toolkit";
 import { ReactNode, useCallback, useContext, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { TrackItem } from "../../../common/project/TrackItem";
-import { zeroPad } from "../../../common/utils";
 import cameraSound from "../../audio/camera.wav";
 import useDeviceList from "../../hooks/useDeviceList";
 import useProjectAndTake from "../../hooks/useProjectAndTake";
@@ -13,7 +12,7 @@ import {
   ImagingDevice,
   deviceIdentifierToDevice,
 } from "../../services/imagingDevice/ImagingDevice";
-import { makeFrameFilePath, makeFrameTrackItem } from "../../services/project/projectBuilder";
+import { makeFrameTrackItem } from "../../services/project/projectBuilder";
 import { getNextFileNumber } from "../../services/project/projectCalculator";
 import * as rLogger from "../../services/rLogger/rLogger";
 import CaptureContext from "./CaptureContext";
@@ -46,8 +45,7 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     // Frame track items should be created synchronously to ensure frames are created in the correct order
     // and do not have overwriting file names
     const fileNumber = getNextFileNumber(take.frameTrack);
-    const filePath = makeFrameFilePath(take, zeroPad(fileNumber, 5));
-    const trackItem = makeFrameTrackItem(filePath, fileNumber);
+    const trackItem = makeFrameTrackItem(take, fileNumber);
     dispatch(addFrameTrackItem(trackItem));
 
     // Intentionally fire async method without await

--- a/src/renderer/context/PersistedDirectoriesContext/PersistedDirectoriesContextProvider.tsx
+++ b/src/renderer/context/PersistedDirectoriesContext/PersistedDirectoriesContextProvider.tsx
@@ -8,7 +8,6 @@ import {
 } from "../../services/database/PersistedDirectoryEntry";
 import useWorkingDirectory from "../../hooks/useWorkingDirectory";
 import { Project } from "../../../common/project/Project";
-import { makeProjectDirectoryName } from "../../services/project/projectBuilder";
 import { PROJECT_DIRECTORY_EXTENSION } from "../../../common/utils";
 import { ProjectDirectoryIsInsideAnotherProjectError } from "./PersistedDirectoriesErrors";
 
@@ -39,9 +38,7 @@ export const PersistedDirectoriesContextProvider = ({
       throw new ProjectDirectoryIsInsideAnotherProjectError(workingDirectory.handle.name);
     }
 
-    const projectDirectoryName = makeProjectDirectoryName(project);
-
-    const handle = await createDirectory!(projectDirectoryName, workingDirectory.handle, true);
+    const handle = await createDirectory!(project.directoryName, workingDirectory.handle, true);
 
     return addProjectDirectoryEntry(project.name, handle);
   };

--- a/src/renderer/context/PlaybackContext/PlaybackContextProvider.tsx
+++ b/src/renderer/context/PlaybackContext/PlaybackContextProvider.tsx
@@ -118,7 +118,7 @@ const PlaybackContextProvider = ({
     stopPlayback();
     rLogger.info(
       "playback.deleteFrameAtCurrentTimelineIndex.deleted",
-      `deleted track item ${trackItem.filePath}`
+      `deleted track item ${trackItem.fileName}`
     );
     await deleteTrackItem?.(trackItem.id);
     notifications.show({ message: "Deleted frame" });

--- a/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
+++ b/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
@@ -66,6 +66,10 @@ export const ProjectFilesContextProvider = ({ children }: ProjectFilesContextPro
     dispatch(removeFrameTrackItem(trackItemId));
   };
 
+  // const updateProjectAndTakeLastSaved = async (project: Project, take: Take) => {
+  //   const updatedProject = {...project, la}
+  // }
+
   const saveProjectInfoFileToDisk = async (project: Project, takes: Take[]): Promise<void> => {
     rLogger.info("projectFilesContext.saveProject", "Saving project json to disk");
     if (projectDirectory === undefined) {
@@ -76,7 +80,6 @@ export const ProjectFilesContextProvider = ({ children }: ProjectFilesContextPro
     const profileFileString = JSON.stringify(projectFileJson);
     const data = new Blob([profileFileString], { type: "application/json" });
 
-    // TODO error handling
     if (projectInfoFileId) {
       await updateFile!(projectInfoFileId, data);
     } else {

--- a/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
+++ b/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
@@ -66,9 +66,12 @@ export const ProjectFilesContextProvider = ({ children }: ProjectFilesContextPro
     dispatch(removeFrameTrackItem(trackItemId));
   };
 
-  // const updateProjectAndTakeLastSaved = async (project: Project, take: Take) => {
-  //   const updatedProject = {...project, la}
-  // }
+  const updateProjectAndTakeLastSaved = (project: Project, take: Take): [Project, Take[]] => {
+    const lastSaved = new Date().toISOString();
+    const updatedProject: Project = { ...project, lastSaved };
+    const updatedTake: Take = { ...take, lastSaved };
+    return [updatedProject, [updatedTake]];
+  };
 
   const saveProjectInfoFileToDisk = async (project: Project, takes: Take[]): Promise<void> => {
     rLogger.info("projectFilesContext.saveProject", "Saving project json to disk");
@@ -95,7 +98,8 @@ export const ProjectFilesContextProvider = ({ children }: ProjectFilesContextPro
 
   useEffect(() => {
     if (projectDirectory !== undefined && project !== undefined && take !== undefined) {
-      saveProjectInfoFileToDisk!(project, [take]);
+      const [updatedProject, updatedTakes] = updateProjectAndTakeLastSaved(project, take);
+      saveProjectInfoFileToDisk!(updatedProject, updatedTakes);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project, take, projectDirectory]);

--- a/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
+++ b/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
@@ -8,10 +8,9 @@ import { Take } from "../../../common/project/Take";
 import { TrackItem } from "../../../common/project/TrackItem";
 import {
   makeTakeDirectoryName,
-  makeFrameFileName,
   makeProjectInfoFileJson,
 } from "../../services/project/projectBuilder";
-import { PROJECT_INFO_FILE_NAME, zeroPad } from "../../../common/utils";
+import { PROJECT_INFO_FILE_NAME } from "../../../common/utils";
 import { FileInfoType } from "../FileManagerContext/FileInfo";
 
 import { Project } from "../../../common/project/Project";
@@ -46,9 +45,8 @@ export const ProjectFilesContextProvider = ({ children }: ProjectFilesContextPro
 
     const takeDirectoryName = makeTakeDirectoryName(take);
     const takeDirectoryHandle = await createDirectory!(takeDirectoryName, projectDirectory.handle);
-    const frameFileName = makeFrameFileName(take, zeroPad(trackItem.fileNumber, 5));
     const fileInfoId = await createFile!(
-      frameFileName,
+      trackItem.fileName,
       takeDirectoryHandle,
       FileInfoType.FRAME,
       data

--- a/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
+++ b/src/renderer/context/ProjectFilesContext.tsx/ProjectFilesContextProvider.tsx
@@ -72,7 +72,7 @@ export const ProjectFilesContextProvider = ({ children }: ProjectFilesContextPro
   };
 
   const saveProjectInfoFileToDisk = async (project: Project, takes: Take[]): Promise<void> => {
-    rLogger.info("projectFilesContext.saveProject", "Saving project json to disk");
+    rLogger.info("projectFilesContext.saveProject", "Saving project info file to disk");
     if (projectDirectory === undefined) {
       throw "Unable to save project file info as missing projectDirectory";
     }
@@ -82,8 +82,16 @@ export const ProjectFilesContextProvider = ({ children }: ProjectFilesContextPro
     const data = new Blob([profileFileString], { type: "application/json" });
 
     if (projectInfoFileId) {
+      rLogger.info(
+        "projectFilesContext.saveProject.update",
+        `Updating project info file ${projectInfoFileId}`
+      );
       await updateFile!(projectInfoFileId, data);
     } else {
+      rLogger.info(
+        "projectFilesContext.saveProject.create",
+        `Creating new project info file in ${projectDirectory.handle.name}`
+      );
       const fileInfoId = await createFile!(
         PROJECT_INFO_FILE_NAME,
         projectDirectory.handle,

--- a/src/renderer/services/project/projectBuilder.test.ts
+++ b/src/renderer/services/project/projectBuilder.test.ts
@@ -1,14 +1,13 @@
 import {
   MOCK_DATE_TIME,
   MOCK_ISO_DATE_TIME_STRING,
-  PROJECT,
-  PROJECT_FILE_NAME,
+  PROJECT_DIRECTORY_NAME,
   PROJECT_NAME,
   TAKE,
   TRACK_GROUP_ID,
 } from "../../../common/testConstants";
 import {
-  DEFAULT_PROJECT_FILE_NAME,
+  DEFAULT_PROJECT_NAME_FORMATTED,
   DEFAULT_PROJECT_NAME,
   PROJECT_DIRECTORY_EXTENSION,
 } from "../../../common/utils";
@@ -16,12 +15,9 @@ import {
   formatProjectName,
   makeFrameTrackItem,
   makeProject,
-  makeProjectDirectoryName,
   makeTake,
   makeTakeDirectoryPath,
 } from "./projectBuilder";
-
-const projectDirectory = `${PROJECT_FILE_NAME}.${PROJECT_DIRECTORY_EXTENSION}`;
 
 beforeEach(() => {
   jest.useFakeTimers({ now: MOCK_DATE_TIME });
@@ -35,7 +31,7 @@ describe("makeProject", () => {
   it("should make project with the supplied options", () => {
     expect(makeProject({ name: PROJECT_NAME, projectFrameRate: 1 })).toEqual({
       name: PROJECT_NAME,
-      fileName: PROJECT_FILE_NAME,
+      directoryName: PROJECT_DIRECTORY_NAME,
       lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 1,
     });
@@ -45,7 +41,7 @@ describe("makeProject", () => {
     const projectName = "a".repeat(256);
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: "a".repeat(256),
-      fileName: "a".repeat(60),
+      directoryName: `${"a".repeat(60)}.${PROJECT_DIRECTORY_EXTENSION}`,
       lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
@@ -55,7 +51,7 @@ describe("makeProject", () => {
     const projectName = ' 🚢<>:"My/\\|Test ?*.Movié 01!龙🐸 ';
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
-      fileName: "🚢MyTest-Movié-01!龙🐸",
+      directoryName: `🚢MyTest-Movié-01!龙🐸.${PROJECT_DIRECTORY_EXTENSION}`,
       lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
@@ -65,7 +61,7 @@ describe("makeProject", () => {
     const projectName = "";
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
-      fileName: expect.stringContaining(DEFAULT_PROJECT_FILE_NAME),
+      directoryName: expect.stringContaining(DEFAULT_PROJECT_NAME_FORMATTED),
       lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
@@ -75,7 +71,7 @@ describe("makeProject", () => {
     const projectName = ' <>:"/\\|?*. ';
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
-      fileName: expect.stringContaining(DEFAULT_PROJECT_FILE_NAME),
+      directoryName: expect.stringContaining(DEFAULT_PROJECT_NAME_FORMATTED),
       lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
@@ -133,12 +129,6 @@ describe("makeFrameTrackItem", () => {
       fileNumber,
       trackGroupId,
     });
-  });
-});
-
-describe("makeProjectDirectoryName", () => {
-  it("should make project directory name with supplied options", () => {
-    expect(makeProjectDirectoryName(PROJECT)).toBe(projectDirectory);
   });
 });
 

--- a/src/renderer/services/project/projectBuilder.test.ts
+++ b/src/renderer/services/project/projectBuilder.test.ts
@@ -1,4 +1,6 @@
 import {
+  MOCK_DATE_TIME,
+  MOCK_ISO_DATE_TIME_STRING,
   PROJECT,
   PROJECT_FILE_NAME,
   PROJECT_NAME,
@@ -22,11 +24,20 @@ import {
 
 const projectDirectory = `${PROJECT_FILE_NAME}.${PROJECT_DIRECTORY_EXTENSION}`;
 
+beforeEach(() => {
+  jest.useFakeTimers({ now: MOCK_DATE_TIME });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe("makeProject", () => {
   it("should make project with the supplied options", () => {
     expect(makeProject({ name: PROJECT_NAME, projectFrameRate: 1 })).toEqual({
       name: PROJECT_NAME,
       fileName: PROJECT_FILE_NAME,
+      lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 1,
     });
   });
@@ -36,6 +47,7 @@ describe("makeProject", () => {
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: "a".repeat(256),
       fileName: "a".repeat(60),
+      lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
   });
@@ -45,6 +57,7 @@ describe("makeProject", () => {
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
       fileName: "🚢MyTest-Movié-01!龙🐸",
+      lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
   });
@@ -54,6 +67,7 @@ describe("makeProject", () => {
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
       fileName: expect.stringContaining(DEFAULT_PROJECT_FILE_NAME),
+      lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
   });
@@ -63,6 +77,7 @@ describe("makeProject", () => {
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
       fileName: expect.stringContaining(DEFAULT_PROJECT_FILE_NAME),
+      lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
   });

--- a/src/renderer/services/project/projectBuilder.test.ts
+++ b/src/renderer/services/project/projectBuilder.test.ts
@@ -14,7 +14,6 @@ import {
 } from "../../../common/utils";
 import {
   formatProjectName,
-  makeFrameFilePath,
   makeFrameTrackItem,
   makeProject,
   makeProjectDirectoryName,
@@ -111,12 +110,12 @@ describe("makeTake", () => {
 });
 
 describe("makeFrameTrackItem", () => {
-  const filePath = "/frame.jpg";
-  const fileNumber = 0;
+  const fileName = "ba_001_01_frame_00001.jpg";
+  const fileNumber = 1;
 
   it("should make frame track item with no Track Group ID supplied", () => {
-    expect(makeFrameTrackItem(filePath, fileNumber)).toStrictEqual({
-      filePath,
+    expect(makeFrameTrackItem(TAKE, fileNumber)).toStrictEqual({
+      fileName,
       id: expect.any(String),
       length: 1,
       fileNumber,
@@ -127,8 +126,8 @@ describe("makeFrameTrackItem", () => {
   it("should make frame track item with Track Group ID supplied", () => {
     const trackGroupId = TRACK_GROUP_ID;
 
-    expect(makeFrameTrackItem(filePath, fileNumber, trackGroupId)).toStrictEqual({
-      filePath,
+    expect(makeFrameTrackItem(TAKE, fileNumber, trackGroupId)).toStrictEqual({
+      fileName,
       id: expect.any(String),
       length: 1,
       fileNumber,
@@ -146,13 +145,5 @@ describe("makeProjectDirectoryName", () => {
 describe("makeTakeDirectoryPath", () => {
   it("should make take directory path with supplied options", () => {
     expect(makeTakeDirectoryPath(TAKE)).toEqual("BA_001_01");
-  });
-});
-
-describe("makeFrameFilePath", () => {
-  it("should make expected frame file path", () => {
-    const fileName = "cheese";
-
-    expect(makeFrameFilePath(TAKE, fileName)).toEqual("BA_001_01/ba_001_01_frame_cheese.jpg");
   });
 });

--- a/src/renderer/services/project/projectBuilder.test.ts
+++ b/src/renderer/services/project/projectBuilder.test.ts
@@ -10,13 +10,14 @@ import {
   DEFAULT_PROJECT_NAME_FORMATTED,
   DEFAULT_PROJECT_NAME,
   PROJECT_DIRECTORY_EXTENSION,
+  DEFAULT_PROJECT_DIRECTORY_NAME,
 } from "../../../common/utils";
 import {
-  formatProjectName,
   makeFrameTrackItem,
   makeProject,
   makeTake,
   makeTakeDirectoryPath,
+  makeUniqueProjectDirectoryNameIfRequired,
 } from "./projectBuilder";
 
 beforeEach(() => {
@@ -61,7 +62,7 @@ describe("makeProject", () => {
     const projectName = "";
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
-      directoryName: expect.stringContaining(DEFAULT_PROJECT_NAME_FORMATTED),
+      directoryName: DEFAULT_PROJECT_DIRECTORY_NAME,
       lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
@@ -71,21 +72,28 @@ describe("makeProject", () => {
     const projectName = ' <>:"/\\|?*. ';
     expect(makeProject({ name: projectName, projectFrameRate: 15 })).toEqual({
       name: projectName,
-      directoryName: expect.stringContaining(DEFAULT_PROJECT_NAME_FORMATTED),
+      directoryName: DEFAULT_PROJECT_DIRECTORY_NAME,
       lastSaved: MOCK_ISO_DATE_TIME_STRING,
       projectFrameRate: 15,
     });
   });
 });
 
-describe("formatProjectName", () => {
-  it("should trim whitespace from project name", () => {
-    expect(formatProjectName(` My Movie \r\n\t`)).toBe("My Movie");
+describe("makeUniqueProjectDirectoryNameIfRequired", () => {
+  it("should make name unique if default project directory name supplied", () => {
+    const defaultProjectDirectoryNameRegex = expect.stringMatching(
+      /^Untitled-Movie-[a-zA-Z0-9]{6,}.boatsfiles$/
+    );
+    expect(makeUniqueProjectDirectoryNameIfRequired(DEFAULT_PROJECT_DIRECTORY_NAME)).toEqual(
+      defaultProjectDirectoryNameRegex
+    );
   });
 
-  it("should use default project name if name is blank or only whitespace", () => {
-    expect(formatProjectName("")).toBe(DEFAULT_PROJECT_NAME);
-    expect(formatProjectName(` \r\n\t`)).toBe(DEFAULT_PROJECT_NAME);
+  it("should not change name if default project directory name is not supplied", () => {
+    const name1 = "cheese.boatsfiles";
+    expect(makeUniqueProjectDirectoryNameIfRequired(name1)).toEqual(name1);
+    const name2 = "  trimming whitespace or missing extension is not handled here   ";
+    expect(makeUniqueProjectDirectoryNameIfRequired(name2)).toEqual(name2);
   });
 });
 

--- a/src/renderer/services/project/projectBuilder.ts
+++ b/src/renderer/services/project/projectBuilder.ts
@@ -64,13 +64,13 @@ export const makeTake = ({ shotNumber, takeNumber, frameRate }: ProjectBuilderOp
 });
 
 export const makeFrameTrackItem = (
-  filePath: string,
+  take: Take,
   fileNumber: number,
   trackGroupId?: TrackGroupId
 ): TrackItem => ({
   id: uuidv4(),
   length: 1,
-  filePath,
+  fileName: makeFrameFileName(take, fileNumber),
   fileNumber,
   trackGroupId: trackGroupId ?? uuidv4(),
 });
@@ -84,26 +84,14 @@ export const makeTakeDirectoryName = (take: Take) =>
 export const makeTakeDirectoryPath = (take: Take) =>
   window.preload.joinPath(`BA_${zeroPad(take.shotNumber, 3)}_${zeroPad(take.takeNumber, 2)}`);
 
-export const makeFrameFileName = (take: Take, frameName: string) =>
+export const makeFrameFileName = (take: Take, frameNumber: number) =>
   [
     "ba",
     zeroPad(take.shotNumber, 3),
     zeroPad(take.takeNumber, 2),
     "frame",
-    `${frameName}.jpg`,
+    `${zeroPad(frameNumber, 5)}.jpg`,
   ].join("_");
-
-export const makeFrameFilePath = (take: Take, frameName: string): string =>
-  window.preload.joinPath(
-    makeTakeDirectoryPath(take),
-    [
-      "ba",
-      zeroPad(take.shotNumber, 3),
-      zeroPad(take.takeNumber, 2),
-      "frame",
-      `${frameName}.jpg`,
-    ].join("_")
-  );
 
 export const makeProjectInfoFileJson = async (
   project: Project,

--- a/src/renderer/services/project/projectBuilder.ts
+++ b/src/renderer/services/project/projectBuilder.ts
@@ -5,9 +5,9 @@ import { Take } from "../../../common/project/Take";
 import { TrackItem } from "../../../common/project/TrackItem";
 import {
   DEFAULT_PROJECT_NAME_FORMATTED,
-  DEFAULT_PROJECT_NAME,
   PROJECT_DIRECTORY_EXTENSION,
   zeroPad,
+  DEFAULT_PROJECT_DIRECTORY_NAME,
 } from "../../../common/utils";
 import { Project } from "../../../common/project/Project";
 import {
@@ -35,21 +35,23 @@ export const makeProject = ({
 });
 
 const makeProjectDirectoryName = (name: string) => {
-  const directoryNameFormatted = name
+  const directoryName = name
     .replace(/[<>:"/\\|?*.]/g, "")
     .substring(0, 60)
     .trim()
     .replace(/ /g, "-");
-  const directoryName =
-    directoryNameFormatted === "" ? makeUniqueDefaultProjectFileName() : directoryNameFormatted;
-  return `${directoryName}.${PROJECT_DIRECTORY_EXTENSION}`;
+  return directoryName === ""
+    ? DEFAULT_PROJECT_DIRECTORY_NAME
+    : `${directoryName}.${PROJECT_DIRECTORY_EXTENSION}`;
 };
 
-const makeUniqueDefaultProjectFileName = () =>
-  `${DEFAULT_PROJECT_NAME_FORMATTED}-${uuidv4().substring(0, 6)}`;
+export const makeUniqueProjectDirectoryNameIfRequired = (directoryName: string) =>
+  directoryName === DEFAULT_PROJECT_DIRECTORY_NAME
+    ? makeUniqueDefaultProjectDirectoryName()
+    : directoryName;
 
-export const formatProjectName = (name: string) =>
-  name.trim() === "" ? DEFAULT_PROJECT_NAME : name.trim();
+const makeUniqueDefaultProjectDirectoryName = () =>
+  `${DEFAULT_PROJECT_NAME_FORMATTED}-${uuidv4().substring(0, 6)}.${PROJECT_DIRECTORY_EXTENSION}`;
 
 export const makeTake = ({ shotNumber, takeNumber, frameRate }: ProjectBuilderOptions): Take => ({
   id: uuidv4(),

--- a/src/renderer/services/project/projectBuilder.ts
+++ b/src/renderer/services/project/projectBuilder.ts
@@ -31,6 +31,7 @@ export const makeProject = ({
   name: name.substring(0, 256),
   fileName: makeProjectFileName(name),
   projectFrameRate,
+  lastSaved: new Date().toISOString(),
 });
 
 const makeProjectFileName = (name: string) => {

--- a/src/renderer/services/project/projectBuilder.ts
+++ b/src/renderer/services/project/projectBuilder.ts
@@ -4,7 +4,7 @@ import { TrackGroupId } from "../../../common/Flavors";
 import { Take } from "../../../common/project/Take";
 import { TrackItem } from "../../../common/project/TrackItem";
 import {
-  DEFAULT_PROJECT_FILE_NAME,
+  DEFAULT_PROJECT_NAME_FORMATTED,
   DEFAULT_PROJECT_NAME,
   PROJECT_DIRECTORY_EXTENSION,
   zeroPad,
@@ -29,22 +29,24 @@ export const makeProject = ({
   projectFrameRate: number;
 }): Project => ({
   name: name.substring(0, 256),
-  fileName: makeProjectFileName(name),
+  directoryName: makeProjectDirectoryName(name),
   projectFrameRate,
   lastSaved: new Date().toISOString(),
 });
 
-const makeProjectFileName = (name: string) => {
-  const fileName = name
+const makeProjectDirectoryName = (name: string) => {
+  const directoryNameFormatted = name
     .replace(/[<>:"/\\|?*.]/g, "")
     .substring(0, 60)
     .trim()
     .replace(/ /g, "-");
-  return fileName === "" ? makeUniqueDefaultProjectFileName() : fileName;
+  const directoryName =
+    directoryNameFormatted === "" ? makeUniqueDefaultProjectFileName() : directoryNameFormatted;
+  return `${directoryName}.${PROJECT_DIRECTORY_EXTENSION}`;
 };
 
 const makeUniqueDefaultProjectFileName = () =>
-  `${DEFAULT_PROJECT_FILE_NAME}-${uuidv4().substring(0, 6)}`;
+  `${DEFAULT_PROJECT_NAME_FORMATTED}-${uuidv4().substring(0, 6)}`;
 
 export const formatProjectName = (name: string) =>
   name.trim() === "" ? DEFAULT_PROJECT_NAME : name.trim();
@@ -74,9 +76,6 @@ export const makeFrameTrackItem = (
   fileNumber,
   trackGroupId: trackGroupId ?? uuidv4(),
 });
-
-export const makeProjectDirectoryName = (project: Project) =>
-  `${project.fileName}.${PROJECT_DIRECTORY_EXTENSION}`;
 
 export const makeTakeDirectoryName = (take: Take) =>
   `BA_${zeroPad(take.shotNumber, 3)}_${zeroPad(take.takeNumber, 2)}`;

--- a/src/renderer/services/project/projectBuilder.ts
+++ b/src/renderer/services/project/projectBuilder.ts
@@ -50,6 +50,7 @@ export const formatProjectName = (name: string) =>
 
 export const makeTake = ({ shotNumber, takeNumber, frameRate }: ProjectBuilderOptions): Take => ({
   id: uuidv4(),
+  lastSaved: new Date().toISOString(),
   shotNumber,
   takeNumber,
   frameRate,

--- a/src/renderer/services/project/projectCalculator.test.ts
+++ b/src/renderer/services/project/projectCalculator.test.ts
@@ -2,6 +2,7 @@ import { FileInfoType } from "../../context/FileManagerContext/FileInfo";
 import { Track } from "../../../common/project/Track";
 import { getLastTrackItem, getNextFileNumber } from "./projectCalculator";
 import { makeFrameTrackItem } from "./projectBuilder";
+import { TAKE } from "../../../common/testConstants";
 
 describe("getNextFileNumber", () => {
   it("should get next file number for track with no items", () => {
@@ -22,7 +23,7 @@ describe("getNextFileNumber", () => {
         {
           id: "trackItemId",
           length: 1,
-          filePath: "somewhere.jpg",
+          fileName: "somewhere.jpg",
           fileNumber: 1,
           trackGroupId: "trackGroupId",
         },
@@ -35,7 +36,7 @@ describe("getNextFileNumber", () => {
         {
           id: "trackItemId",
           length: 1,
-          filePath: "somewhere.jpg",
+          fileName: "somewhere.jpg",
           fileNumber: 7,
           trackGroupId: "trackGroupId",
         },
@@ -49,8 +50,8 @@ describe("getNextFileNumber", () => {
 
 describe("getLastTrackItem", () => {
   it("should get last track item in track", () => {
-    const trackItem1 = makeFrameTrackItem("somewhere.jpg", 1);
-    const trackItem2 = makeFrameTrackItem("somewhere2.jpg", 2);
+    const trackItem1 = makeFrameTrackItem(TAKE, 1);
+    const trackItem2 = makeFrameTrackItem(TAKE, 2);
     const track: Track = {
       id: "trackId",
       fileType: FileInfoType.FRAME,

--- a/src/renderer/services/project/projectCalculator.ts
+++ b/src/renderer/services/project/projectCalculator.ts
@@ -28,7 +28,7 @@ export const getHighlightedTrackItem = (
 export const getTrackItemTitle = (track: Track, trackItemIndex: number) =>
   track.fileType === FileInfoType.FRAME
     ? `Frame ${getTrackItemStartPosition(track, trackItemIndex) + 1}`
-    : track.trackItems[trackItemIndex].filePath;
+    : track.trackItems[trackItemIndex].fileName;
 
 const getLastFileNumberInTrack = (track: Track): number => track.trackItems.at(-1)?.fileNumber ?? 0;
 


### PR DESCRIPTION
* Store last saved datetime for the current project and current take
* Store actual project directory name rather than version without extension
* Make default project name on submit rather than before
* Store file name rather than file path for track items
* (unrelated) fix redux/react dev tools extensions not initialising on macOS