### PR TITLE
Implement change resolution

### DIFF
--- a/src/renderer/components/animator/CaptureSidebarBlock/CaptureSidebarBlock.tsx
+++ b/src/renderer/components/animator/CaptureSidebarBlock/CaptureSidebarBlock.tsx
@@ -8,14 +8,14 @@ import { SemanticColor } from "../../ui/Theme/SemanticColor";
 import { UiButton } from "../../ui/UiButton/UiButton";
 
 const CaptureSidebarBlock = () => {
-  const { deviceStatus } = useContext(ImagingDeviceContext);
+  const { deviceIdentifier } = useContext(ImagingDeviceContext);
 
   return (
     <SidebarBlock title="Capture">
       <InputGroup>
         <InputLabel inputId="camera-source-select">Capture Source</InputLabel>
         <UiButton semanticColor={SemanticColor.PRIMARY} onClick={PageRoute.ANIMATOR_CAPTURE_SOURCE}>
-          {deviceStatus?.identifier?.name ?? "Select Capture Source"}
+          {deviceIdentifier?.name ?? "Select Capture Source"}
         </UiButton>
       </InputGroup>
     </SidebarBlock>

--- a/src/renderer/components/animator/Preview/Preview.tsx
+++ b/src/renderer/components/animator/Preview/Preview.tsx
@@ -37,17 +37,22 @@ export const Preview = (): JSX.Element => {
     );
   }
 
+  if (deviceLoading) {
+    return (
+      <div className="preview">
+        <PreviewLoader />
+      </div>
+    );
+  }
+
   return (
     <div className="preview">
-      {!deviceLoading && deviceIdentifier === undefined && (
-        <h2>Select a Capture Source to begin!</h2>
-      )}
+      {deviceIdentifier === undefined && <h2>Select a Capture Source to begin!</h2>}
       {deviceIdentifier && deviceStream === undefined && (
         <h2>Select a Capture Resolution to begin!</h2>
       )}
-      {!deviceLoading && deviceStream && <PreviewLiveView stream={deviceStream} />}
+      {deviceStream && <PreviewLiveView stream={deviceStream} />}
       <PreviewFrame src={previewSrc} hidden={liveViewVisible} />
-      {deviceLoading && <PreviewLoader />}
     </div>
   );
 };

--- a/src/renderer/components/animator/Preview/Preview.tsx
+++ b/src/renderer/components/animator/Preview/Preview.tsx
@@ -12,7 +12,7 @@ import { PreviewLoader } from "./PreviewLoader/PreviewLoader";
 
 export const Preview = (): JSX.Element => {
   const { take } = useProjectAndTake();
-  const { deviceIdentifier, deviceStream, deviceLoading } = useContext(ImagingDeviceContext);
+  const { deviceIdentifier, deviceStatus, deviceLoading } = useContext(ImagingDeviceContext);
 
   const { getTrackItemFileInfo } = useContext(ProjectFilesContext);
   const { hasCameraAccess } = useContext(ImagingDeviceContext);
@@ -48,10 +48,10 @@ export const Preview = (): JSX.Element => {
   return (
     <div className="preview">
       {deviceIdentifier === undefined && <h2>Select a Capture Source to begin!</h2>}
-      {deviceIdentifier && deviceStream === undefined && (
+      {deviceIdentifier && deviceStatus === undefined && (
         <h2>Select a Capture Resolution to begin!</h2>
       )}
-      {deviceStream && <PreviewLiveView stream={deviceStream} />}
+      <PreviewLiveView stream={deviceStatus?.stream} />
       <PreviewFrame src={previewSrc} hidden={liveViewVisible} />
     </div>
   );

--- a/src/renderer/components/animator/Preview/Preview.tsx
+++ b/src/renderer/components/animator/Preview/Preview.tsx
@@ -12,7 +12,7 @@ import { PreviewLoader } from "./PreviewLoader/PreviewLoader";
 
 export const Preview = (): JSX.Element => {
   const { take } = useProjectAndTake();
-  const { device, deviceStatus, deviceReady } = useContext(ImagingDeviceContext);
+  const { deviceIdentifier, deviceStream, deviceReady } = useContext(ImagingDeviceContext);
 
   const { getTrackItemFileInfo } = useContext(ProjectFilesContext);
   const { hasCameraAccess } = useContext(ImagingDeviceContext);
@@ -25,25 +25,24 @@ export const Preview = (): JSX.Element => {
 
   const previewSrc = highlightedTrackItem ? getTrackItemObjectURL(highlightedTrackItem) : undefined;
 
+  if (!hasCameraAccess) {
+    return (
+      <div className="preview">
+        <h2>
+          You have denied camera access to this application.
+          <br />
+          Please enable access in System Preferences and restart Boats Animator.
+        </h2>
+      </div>
+    );
+  }
+
   return (
     <div className="preview">
-      {deviceStatus && hasCameraAccess && <PreviewLiveView stream={device.current?.stream} />}
-
-      {liveViewVisible &&
-        !deviceStatus &&
-        (hasCameraAccess ? (
-          <h2>Select a Capture Source to begin!</h2>
-        ) : (
-          <h2>
-            You have denied camera access to this application.
-            <br />
-            Please enable access in System Preferences and restart Boats Animator.
-          </h2>
-        ))}
-
+      {deviceIdentifier === undefined && <h2>Select a Capture Source to begin!</h2>}
+      {deviceStream && <PreviewLiveView stream={deviceStream} />}
       <PreviewFrame src={previewSrc} hidden={liveViewVisible} />
-
-      {deviceStatus?.open === true && !deviceReady && <PreviewLoader />}
+      {!deviceReady && <PreviewLoader />}
     </div>
   );
 };

--- a/src/renderer/components/animator/Preview/Preview.tsx
+++ b/src/renderer/components/animator/Preview/Preview.tsx
@@ -12,7 +12,7 @@ import { PreviewLoader } from "./PreviewLoader/PreviewLoader";
 
 export const Preview = (): JSX.Element => {
   const { take } = useProjectAndTake();
-  const { deviceIdentifier, deviceStream, deviceReady } = useContext(ImagingDeviceContext);
+  const { deviceIdentifier, deviceStream, deviceLoading } = useContext(ImagingDeviceContext);
 
   const { getTrackItemFileInfo } = useContext(ProjectFilesContext);
   const { hasCameraAccess } = useContext(ImagingDeviceContext);
@@ -39,10 +39,12 @@ export const Preview = (): JSX.Element => {
 
   return (
     <div className="preview">
-      {deviceIdentifier === undefined && <h2>Select a Capture Source to begin!</h2>}
-      {deviceStream && <PreviewLiveView stream={deviceStream} />}
+      {!deviceLoading && deviceIdentifier === undefined && (
+        <h2>Select a Capture Source to begin!</h2>
+      )}
+      {!deviceLoading && deviceStream && <PreviewLiveView stream={deviceStream} />}
       <PreviewFrame src={previewSrc} hidden={liveViewVisible} />
-      {!deviceReady && <PreviewLoader />}
+      {deviceLoading && <PreviewLoader />}
     </div>
   );
 };

--- a/src/renderer/components/animator/Preview/Preview.tsx
+++ b/src/renderer/components/animator/Preview/Preview.tsx
@@ -42,6 +42,9 @@ export const Preview = (): JSX.Element => {
       {!deviceLoading && deviceIdentifier === undefined && (
         <h2>Select a Capture Source to begin!</h2>
       )}
+      {deviceIdentifier && deviceStream === undefined && (
+        <h2>Select a Capture Resolution to begin!</h2>
+      )}
       {!deviceLoading && deviceStream && <PreviewLiveView stream={deviceStream} />}
       <PreviewFrame src={previewSrc} hidden={liveViewVisible} />
       {deviceLoading && <PreviewLoader />}

--- a/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
+++ b/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
@@ -16,7 +16,7 @@ import { UiSelect } from "../../ui/UiSelect/UiSelect";
 export const CaptureSourceModal = () => {
   const {
     deviceIdentifier,
-    deviceReady,
+    deviceLoading,
     deviceResolution,
     changeDevice,
     changeResolution,
@@ -49,7 +49,7 @@ export const CaptureSourceModal = () => {
 
   return (
     <UiModal title="Capture Source Settings" onClose={PageRoute.ANIMATOR}>
-      {deviceReady ? (
+      {!deviceLoading ? (
         <Stack>
           <UiSelect
             label="Capture Source"

--- a/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
+++ b/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
@@ -62,7 +62,7 @@ export const CaptureSourceModal = () => {
           {deviceIdentifier && (
             <UiSelect
               label="Capture Resolution"
-              placeholder="Loading resolutions..."
+              placeholder="Select resolution"
               data={makeResolutionSelectData()}
               value={resolutionName}
               onChange={handleChangeResolutionName}

--- a/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
+++ b/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
@@ -6,9 +6,14 @@ import useDeviceList from "../../../hooks/useDeviceList";
 import { UiLoader } from "../../ui/UiLoader/UiLoader";
 import { UiModal } from "../../ui/UiModal/UiModal";
 import { UiSelect } from "../../ui/UiSelect/UiSelect";
+import {
+  makeResolutionSelectData,
+  resolutionToName,
+} from "../../../services/imagingDevice/ImagingDeviceResolution";
 
 export const CaptureSourceModal = () => {
-  const { deviceStatus, deviceReady, changeDevice, closeDevice } = useContext(ImagingDeviceContext);
+  const { deviceStatus, deviceReady, resolution, changeDevice, closeDevice } =
+    useContext(ImagingDeviceContext);
 
   const deviceList = useDeviceList();
   const deviceSelectData: ComboboxData = deviceList.map(({ name, deviceId }) => ({
@@ -34,7 +39,12 @@ export const CaptureSourceModal = () => {
           />
 
           {deviceReady && (
-            <UiSelect label="Capture Resolution" data={[]} value={""} onChange={() => undefined} />
+            <UiSelect
+              label="Capture Resolution"
+              data={makeResolutionSelectData()}
+              value={resolution ? resolutionToName(resolution) : undefined}
+              onChange={() => undefined}
+            />
           )}
         </Stack>
       ) : (

--- a/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
+++ b/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
@@ -17,13 +17,15 @@ export const CaptureSourceModal = () => {
   const {
     deviceIdentifier,
     deviceLoading,
-    deviceResolution,
+    deviceStatus,
     changeDevice,
     changeResolution,
     closeDevice,
   } = useContext(ImagingDeviceContext);
 
-  const resolutionName = deviceResolution ? resolutionToName(deviceResolution) : undefined;
+  const resolutionName = deviceStatus?.resolution
+    ? resolutionToName(deviceStatus.resolution)
+    : undefined;
   const deviceList = useDeviceList();
   const deviceSelectData: ComboboxData = deviceList.map(({ name, deviceId }) => ({
     label: name,
@@ -32,7 +34,6 @@ export const CaptureSourceModal = () => {
 
   const handleChangeDevice = async (newDeviceId: string | undefined) => {
     const identifier = deviceList.find((device) => device.deviceId === newDeviceId);
-    // todo switch back to null device if error
     return identifier ? changeDevice?.(identifier) : closeDevice?.();
   };
 
@@ -41,8 +42,6 @@ export const CaptureSourceModal = () => {
       name !== undefined ? NAME_TO_RESOLUTION[name as ResolutionName] : undefined;
 
     if (newResolution) {
-      // todo switch back to old resolution if error
-      // todo seems to need to use grabFrame when you change resolution
       await changeResolution?.(newResolution);
     }
   };

--- a/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
+++ b/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
@@ -1,18 +1,20 @@
 import { ComboboxData, Stack } from "@mantine/core";
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import { PageRoute } from "../../../../common/PageRoute";
 import { ImagingDeviceContext } from "../../../context/ImagingDeviceContext/ImagingDeviceContext";
 import useDeviceList from "../../../hooks/useDeviceList";
+import {
+  makeResolutionSelectData,
+  NAME_TO_RESOLUTION,
+  ResolutionName,
+  resolutionToName,
+} from "../../../services/imagingDevice/ImagingDeviceResolution";
 import { UiLoader } from "../../ui/UiLoader/UiLoader";
 import { UiModal } from "../../ui/UiModal/UiModal";
 import { UiSelect } from "../../ui/UiSelect/UiSelect";
-import {
-  makeResolutionSelectData,
-  resolutionToName,
-} from "../../../services/imagingDevice/ImagingDeviceResolution";
 
 export const CaptureSourceModal = () => {
-  const { deviceStatus, deviceReady, resolution, changeDevice, closeDevice } =
+  const { deviceStatus, deviceReady, device, changeDevice, changeResolution, closeDevice } =
     useContext(ImagingDeviceContext);
 
   const deviceList = useDeviceList();
@@ -26,6 +28,21 @@ export const CaptureSourceModal = () => {
     return identifier ? changeDevice(identifier) : closeDevice();
   };
 
+  const handleChangeResolution = (name: string | undefined) => {
+    console.log("change to", name);
+    const newResolution =
+      name !== undefined ? NAME_TO_RESOLUTION[name as ResolutionName] : undefined;
+    if (newResolution !== undefined) {
+      changeResolution(newResolution);
+    }
+  };
+
+  const resolution = useMemo(() => {
+    if (deviceReady) {
+      return deviceStatus?.resolution ?? device.current?.getResolution();
+    }
+  }, [device, deviceReady, deviceStatus?.resolution]);
+
   return (
     <UiModal title="Capture Source Settings" onClose={PageRoute.ANIMATOR}>
       {deviceStatus === undefined || deviceReady ? (
@@ -38,12 +55,13 @@ export const CaptureSourceModal = () => {
             onChange={handleChangeDevice}
           />
 
-          {deviceReady && (
+          {deviceReady === true && (
             <UiSelect
               label="Capture Resolution"
+              placeholder="Loading resolutions..."
               data={makeResolutionSelectData()}
-              value={resolution ? resolutionToName(resolution) : undefined}
-              onChange={() => undefined}
+              value={resolution ? resolutionToName(resolution) : resolution}
+              onChange={handleChangeResolution}
             />
           )}
         </Stack>

--- a/src/renderer/components/ui/UiSelect/UiSelect.tsx
+++ b/src/renderer/components/ui/UiSelect/UiSelect.tsx
@@ -2,7 +2,7 @@ import { ComboboxData, ComboboxItem, Select } from "@mantine/core";
 
 interface UiSelectProps {
   label: string;
-  placeholder?: string;
+  placeholder: string;
   data: ComboboxData;
   value: string | undefined;
   onChange: (value: string | undefined, option: ComboboxItem) => void;

--- a/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
+++ b/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
@@ -23,7 +23,7 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     (state: RootState) => state.app.userPreferences.playCaptureSound
   );
   const { saveTrackItemToDisk } = useContext(ProjectFilesContext);
-  const { captureImageRaw, deviceLoading, deviceIdentifier } = useContext(ImagingDeviceContext);
+  const { captureImageRaw, deviceStream, deviceIdentifier } = useContext(ImagingDeviceContext);
 
   const captureImage = async () => {
     rLogger.info("captureContextProvider.captureImage");
@@ -31,7 +31,7 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
       rLogger.info("captureNoDevice", "Nothing captured as no device selected");
       return;
     }
-    if (deviceLoading === true) {
+    if (deviceStream === undefined) {
       rLogger.info("captureDeviceNotReady", "Nothing captured as device is not ready yet");
       return;
     }

--- a/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
+++ b/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
@@ -23,11 +23,11 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     (state: RootState) => state.app.userPreferences.playCaptureSound
   );
   const { saveTrackItemToDisk } = useContext(ProjectFilesContext);
-  const { device, deviceReady } = useContext(ImagingDeviceContext);
+  const { captureImageRaw, deviceReady, deviceIdentifier } = useContext(ImagingDeviceContext);
 
   const captureImage = async () => {
     rLogger.info("captureContextProvider.captureImage");
-    if (device.current === undefined) {
+    if (deviceIdentifier === undefined) {
       rLogger.info("captureNoDevice", "Nothing captured as no device selected");
       return;
     }
@@ -43,7 +43,7 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     }
 
     try {
-      const imageData = await device.current?.captureImage();
+      const imageData = await captureImageRaw?.();
       if (imageData === undefined) {
         throw "Unable to captureImage as no imageData returned";
       }

--- a/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
+++ b/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
@@ -23,15 +23,11 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     (state: RootState) => state.app.userPreferences.playCaptureSound
   );
   const { saveTrackItemToDisk } = useContext(ProjectFilesContext);
-  const { captureImageRaw, deviceStream, deviceIdentifier } = useContext(ImagingDeviceContext);
+  const { captureImageRaw, deviceStatus } = useContext(ImagingDeviceContext);
 
   const captureImage = async () => {
     rLogger.info("captureContextProvider.captureImage");
-    if (deviceIdentifier === undefined) {
-      rLogger.info("captureNoDevice", "Nothing captured as no device selected");
-      return;
-    }
-    if (deviceStream === undefined) {
+    if (deviceStatus === undefined) {
       rLogger.info("captureDeviceNotReady", "Nothing captured as device is not ready yet");
       return;
     }

--- a/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
+++ b/src/renderer/context/CaptureContext/CaptureContextProvider.tsx
@@ -23,7 +23,7 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
     (state: RootState) => state.app.userPreferences.playCaptureSound
   );
   const { saveTrackItemToDisk } = useContext(ProjectFilesContext);
-  const { captureImageRaw, deviceReady, deviceIdentifier } = useContext(ImagingDeviceContext);
+  const { captureImageRaw, deviceLoading, deviceIdentifier } = useContext(ImagingDeviceContext);
 
   const captureImage = async () => {
     rLogger.info("captureContextProvider.captureImage");
@@ -31,7 +31,7 @@ const CaptureContextProvider = ({ children }: CaptureContextProviderProps) => {
       rLogger.info("captureNoDevice", "Nothing captured as no device selected");
       return;
     }
-    if (deviceReady === false) {
+    if (deviceLoading === true) {
       rLogger.info("captureDeviceNotReady", "Nothing captured as device is not ready yet");
       return;
     }

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
@@ -1,12 +1,14 @@
 import { createContext } from "react";
-import { ImagingDeviceIdentifier } from "../../services/imagingDevice/ImagingDevice";
+import {
+  ImagingDeviceIdentifier,
+  ImagingDeviceStatus,
+} from "../../services/imagingDevice/ImagingDevice";
 import { ImagingDeviceResolution } from "../../services/imagingDevice/ImagingDeviceResolution";
 
 interface ImagingDeviceContextProps {
   hasCameraAccess: boolean;
   deviceIdentifier: ImagingDeviceIdentifier | undefined;
-  deviceStream: MediaStream | undefined;
-  deviceResolution: ImagingDeviceResolution | undefined;
+  deviceStatus: ImagingDeviceStatus | undefined;
   deviceLoading: boolean;
   changeDevice?: (identifier: ImagingDeviceIdentifier) => Promise<void>;
   changeResolution?: (resolution: ImagingDeviceResolution) => Promise<void>;
@@ -17,8 +19,7 @@ interface ImagingDeviceContextProps {
 const defaultValue: ImagingDeviceContextProps = {
   hasCameraAccess: false,
   deviceIdentifier: undefined,
-  deviceStream: undefined,
-  deviceResolution: undefined,
+  deviceStatus: undefined,
   deviceLoading: false,
   changeDevice: undefined,
   changeResolution: undefined,

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
@@ -7,7 +7,7 @@ interface ImagingDeviceContextProps {
   deviceIdentifier: ImagingDeviceIdentifier | undefined;
   deviceStream: MediaStream | undefined;
   deviceResolution: ImagingDeviceResolution | undefined;
-  deviceReady: boolean;
+  deviceLoading: boolean;
   changeDevice?: (identifier: ImagingDeviceIdentifier) => Promise<void>;
   changeResolution?: (resolution: ImagingDeviceResolution) => Promise<void>;
   closeDevice?: () => void;
@@ -19,7 +19,7 @@ const defaultValue: ImagingDeviceContextProps = {
   deviceIdentifier: undefined,
   deviceStream: undefined,
   deviceResolution: undefined,
-  deviceReady: false,
+  deviceLoading: false,
   changeDevice: undefined,
   changeResolution: undefined,
   closeDevice: undefined,

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
@@ -1,33 +1,29 @@
-import { createContext, MutableRefObject } from "react";
-import {
-  ImagingDevice,
-  ImagingDeviceIdentifier,
-  ImagingDeviceStatus,
-} from "../../services/imagingDevice/ImagingDevice";
+import { createContext } from "react";
+import { ImagingDeviceIdentifier } from "../../services/imagingDevice/ImagingDevice";
 import { ImagingDeviceResolution } from "../../services/imagingDevice/ImagingDeviceResolution";
 
 interface ImagingDeviceContextProps {
   hasCameraAccess: boolean;
-  device: MutableRefObject<ImagingDevice | undefined>;
-  deviceStatus: ImagingDeviceStatus | undefined;
+  deviceIdentifier: ImagingDeviceIdentifier | undefined;
+  deviceStream: MediaStream | undefined;
+  deviceResolution: ImagingDeviceResolution | undefined;
   deviceReady: boolean;
-  reopenDevice: () => void;
-  pauseDevice: () => void;
-  closeDevice: () => void;
-  changeDevice: (identifier: ImagingDeviceIdentifier) => void;
-  changeResolution: (resolution: ImagingDeviceResolution) => void;
+  changeDevice?: (identifier: ImagingDeviceIdentifier) => Promise<void>;
+  changeResolution?: (resolution: ImagingDeviceResolution) => Promise<void>;
+  closeDevice?: () => void;
+  captureImageRaw?: () => Promise<Blob> | undefined;
 }
 
 const defaultValue: ImagingDeviceContextProps = {
   hasCameraAccess: false,
-  device: { current: undefined },
-  deviceStatus: undefined,
+  deviceIdentifier: undefined,
+  deviceStream: undefined,
+  deviceResolution: undefined,
   deviceReady: false,
-  reopenDevice: () => undefined,
-  pauseDevice: () => undefined,
-  closeDevice: () => undefined,
-  changeDevice: () => undefined,
-  changeResolution: () => undefined,
+  changeDevice: undefined,
+  changeResolution: undefined,
+  closeDevice: undefined,
+  captureImageRaw: undefined,
 };
 
 export const ImagingDeviceContext = createContext<ImagingDeviceContextProps>(defaultValue);

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
@@ -4,12 +4,14 @@ import {
   ImagingDeviceIdentifier,
   ImagingDeviceStatus,
 } from "../../services/imagingDevice/ImagingDevice";
+import { ImagingDeviceResolution } from "../../services/imagingDevice/ImagingDeviceResolution";
 
 interface ImagingDeviceContextProps {
   hasCameraAccess: boolean;
   device: MutableRefObject<ImagingDevice | undefined>;
   deviceStatus: ImagingDeviceStatus | undefined;
   deviceReady: boolean;
+  resolution: ImagingDeviceResolution | undefined;
   reopenDevice: () => void;
   pauseDevice: () => void;
   closeDevice: () => void;
@@ -21,6 +23,7 @@ const defaultValue: ImagingDeviceContextProps = {
   device: { current: undefined },
   deviceStatus: undefined,
   deviceReady: false,
+  resolution: undefined,
   reopenDevice: () => undefined,
   pauseDevice: () => undefined,
   closeDevice: () => undefined,

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContext.ts
@@ -11,11 +11,11 @@ interface ImagingDeviceContextProps {
   device: MutableRefObject<ImagingDevice | undefined>;
   deviceStatus: ImagingDeviceStatus | undefined;
   deviceReady: boolean;
-  resolution: ImagingDeviceResolution | undefined;
   reopenDevice: () => void;
   pauseDevice: () => void;
   closeDevice: () => void;
   changeDevice: (identifier: ImagingDeviceIdentifier) => void;
+  changeResolution: (resolution: ImagingDeviceResolution) => void;
 }
 
 const defaultValue: ImagingDeviceContextProps = {
@@ -23,11 +23,11 @@ const defaultValue: ImagingDeviceContextProps = {
   device: { current: undefined },
   deviceStatus: undefined,
   deviceReady: false,
-  resolution: undefined,
   reopenDevice: () => undefined,
   pauseDevice: () => undefined,
   closeDevice: () => undefined,
   changeDevice: () => undefined,
+  changeResolution: () => undefined,
 };
 
 export const ImagingDeviceContext = createContext<ImagingDeviceContextProps>(defaultValue);

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
@@ -1,18 +1,15 @@
 import { notifications } from "@mantine/notifications";
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useDeviceList from "../../hooks/useDeviceList";
 import {
   deviceIdentifierToDevice,
   ImagingDevice,
   ImagingDeviceIdentifier,
-  ImagingDeviceStatus,
 } from "../../services/imagingDevice/ImagingDevice";
 import { ImagingDeviceContext } from "./ImagingDeviceContext";
 import * as rLogger from "../../services/rLogger/rLogger";
-import {
-  areResolutionsEqual,
-  ImagingDeviceResolution,
-} from "../../services/imagingDevice/ImagingDeviceResolution";
+import { ImagingDeviceResolution } from "../../services/imagingDevice/ImagingDeviceResolution";
+import { v4 as uuidv4 } from "uuid";
 
 interface ImagingDeviceContextProviderProps {
   children: ReactNode;
@@ -22,28 +19,54 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
   const deviceList = useDeviceList();
 
   const [hasCameraAccess, setHasCameraAccess] = useState(false);
+  // todo rename to deviceLoading and swap around true and false
+  const [deviceReady, setDeviceReady] = useState(true);
   const device = useRef<ImagingDevice | undefined>(undefined);
-  const [deviceStatus, setDeviceStatus] = useState<ImagingDeviceStatus | undefined>(undefined);
-  const [deviceReady, setDeviceReady] = useState(false);
 
-  console.log({ device, deviceStatus, deviceReady });
+  const [deviceStateChanged, setDeviceStateChanged] = useState(uuidv4());
+  const triggerDeviceStateChange = () => setDeviceStateChanged(uuidv4());
 
-  const reopenDevice = () => {
-    setDeviceStatus((prev) => (prev ? { ...prev, open: true } : undefined));
-  };
-  const pauseDevice = () => {
-    setDeviceStatus((prev) => (prev ? { ...prev, open: false } : undefined));
-  };
-  const closeDevice = () => {
-    setDeviceStatus(undefined);
-  };
-  const changeDevice = (identifier: ImagingDeviceIdentifier) => {
-    setDeviceStatus({ identifier, open: true, resolution: undefined });
+  // todo can these be combined into a single memo
+  const deviceIdentifier = useMemo(() => device.current?.identifier, [deviceStateChanged]); // eslint-disable-line react-hooks/exhaustive-deps
+  const deviceStream = useMemo(() => device.current?.stream, [deviceStateChanged]); // eslint-disable-line react-hooks/exhaustive-deps
+  const deviceResolution = useMemo(
+    () => (device.current?.stream ? device.current?.getResolution() : undefined),
+    [deviceStateChanged] // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  const changeDevice = async (identifier: ImagingDeviceIdentifier) => {
+    setDeviceReady(false);
+    device.current?.close();
+    const newDevice = deviceIdentifierToDevice(identifier);
+    device.current = newDevice;
+
+    try {
+      await newDevice.open();
+    } finally {
+      setDeviceReady(true);
+      triggerDeviceStateChange();
+    }
   };
 
-  const changeResolution = (resolution: ImagingDeviceResolution) => {
-    setDeviceStatus((prev) => (prev ? { ...prev, resolution } : undefined));
+  const changeResolution = async (resolution: ImagingDeviceResolution) => {
+    setDeviceReady(false);
+    device.current?.close();
+
+    try {
+      await device.current?.open(resolution);
+    } finally {
+      setDeviceReady(true);
+      triggerDeviceStateChange();
+    }
   };
+
+  const closeDevice = useCallback(() => {
+    device.current?.close();
+    device.current = undefined;
+    triggerDeviceStateChange();
+  }, []);
+
+  const captureImageRaw = () => device.current?.captureImage();
 
   useEffect(() => {
     const handleCheckCameraAccess = async () => {
@@ -55,75 +78,34 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
   }, []);
 
   useEffect(() => {
-    const handleDeviceDisconnected = () => {
-      const currentDeviceInDeviceList =
-        deviceList.find(
-          (identifier) => identifier.deviceId === deviceStatus?.identifier.deviceId
-        ) !== undefined;
-      rLogger.info(
-        "deviceDisconnected",
-        `Current device still in device list: ${currentDeviceInDeviceList.toString()}`
+    const handleDeviceDisconnected = async () => {
+      const currentDevice = device.current;
+      const currentDeviceConnected = deviceList.find(
+        (identifier) => identifier.deviceId === currentDevice?.identifier.deviceId
       );
 
-      if (deviceStatus?.identifier && !currentDeviceInDeviceList) {
+      if (currentDevice && !currentDeviceConnected) {
+        rLogger.info("currentDeviceDisconnected", "The current device was disconnected");
         notifications.show({ message: "Current device was disconnected." });
         closeDevice();
       }
     };
+
     handleDeviceDisconnected();
-  }, [deviceList, deviceStatus?.identifier]);
-
-  // useEffect(() => {
-  //   const identifier = deviceStatus?.identifier;
-  //   const newDevice = identifier ? deviceIdentifierToDevice(identifier) : undefined;
-
-  //   if (deviceStatus === )
-  //   setDeviceReady(false);
-
-  //   setDeviceReady(true);
-
-  // }, [deviceStatus?.open])
-
-  // update/close device should be separate to open device
-  useEffect(() => {
-    const handleDeviceStatusChange = async () => {
-      rLogger.info("deviceStatusChange", JSON.stringify(deviceStatus));
-      setDeviceReady(false);
-
-      const identifier = deviceStatus?.identifier;
-      const newDevice = identifier ? deviceIdentifierToDevice(identifier) : undefined;
-
-      device.current?.close();
-      device.current = newDevice;
-
-      if (deviceStatus?.open === true && newDevice !== undefined) {
-        await newDevice.open(deviceStatus.resolution);
-        setDeviceReady(true);
-      }
-    };
-
-    handleDeviceStatusChange();
-
-    return () => {
-      rLogger.info("deviceStatusCleanup", "Device closed as ImagingDeviceContext unmounted");
-      device.current?.close();
-    };
-  }, [deviceStatus]);
-
-  // useEffect(() => {})
+  }, [closeDevice, deviceIdentifier?.deviceId, deviceList]);
 
   return (
     <ImagingDeviceContext.Provider
       value={{
         hasCameraAccess,
-        device,
-        deviceStatus,
+        deviceIdentifier,
+        deviceStream,
+        deviceResolution,
         deviceReady,
-        reopenDevice,
-        pauseDevice,
-        closeDevice,
         changeDevice,
         changeResolution,
+        closeDevice,
+        captureImageRaw,
       }}
     >
       {children}

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../services/imagingDevice/ImagingDevice";
 import { ImagingDeviceContext } from "./ImagingDeviceContext";
 import * as rLogger from "../../services/rLogger/rLogger";
+import { ImagingDeviceResolution } from "../../services/imagingDevice/ImagingDeviceResolution";
 
 interface ImagingDeviceContextProviderProps {
   children: ReactNode;
@@ -21,6 +22,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
   const device = useRef<ImagingDevice | undefined>(undefined);
   const [deviceStatus, setDeviceStatus] = useState<ImagingDeviceStatus | undefined>(undefined);
   const [deviceReady, setDeviceReady] = useState(false);
+  const [resolution, setResolution] = useState<ImagingDeviceResolution | undefined>(undefined);
 
   const reopenDevice = () => {
     setDeviceStatus((prev) => (prev ? { ...prev, open: true } : undefined));
@@ -76,8 +78,9 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
       device.current?.close();
       device.current = newDevice;
 
-      if (deviceStatus?.open === true) {
-        await newDevice?.open();
+      if (deviceStatus?.open === true && newDevice !== undefined) {
+        await newDevice.open();
+        setResolution(newDevice.getResolution());
         setDeviceReady(true);
       }
     };
@@ -97,6 +100,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
         device,
         deviceStatus,
         deviceReady,
+        resolution,
         reopenDevice,
         pauseDevice,
         closeDevice,

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
@@ -22,15 +22,15 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
   const [deviceLoading, setDeviceLoading] = useState(false);
   const device = useRef<ImagingDevice | undefined>(undefined);
 
-  const [deviceStatusKey, setDeviceStatusKey] = useState(uuidv4());
-  const updateDeviceStatus = () => setDeviceStatusKey(uuidv4());
+  const [deviceRefUpdate, setDeviceRefUpdate] = useState(uuidv4());
+  const updateDeviceStatus = () => setDeviceRefUpdate(uuidv4());
 
-  const deviceIdentifier = useMemo(() => device.current?.identifier, [deviceStatusKey]); // eslint-disable-line react-hooks/exhaustive-deps
-  const deviceStream = useMemo(() => device.current?.stream, [deviceStatusKey]); // eslint-disable-line react-hooks/exhaustive-deps
-  const deviceResolution = useMemo(
-    () => (device.current?.stream ? device.current?.getResolution() : undefined),
-    [deviceStatusKey] // eslint-disable-line react-hooks/exhaustive-deps
-  );
+  const deviceIdentifier = useMemo(() => device.current?.identifier, [deviceRefUpdate]); // eslint-disable-line react-hooks/exhaustive-deps
+  const deviceStatus = useMemo(() => {
+    if (device.current?.stream) {
+      return { stream: device.current.stream, resolution: device.current.getResolution() };
+    }
+  }, [deviceRefUpdate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const changeDevice = async (identifier: ImagingDeviceIdentifier) => {
     setDeviceLoading(true);
@@ -109,8 +109,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
       value={{
         hasCameraAccess,
         deviceIdentifier,
-        deviceStream,
-        deviceResolution,
+        deviceStatus,
         deviceLoading,
         changeDevice,
         changeResolution,

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
@@ -61,7 +61,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
       }
       if (e instanceof UnableToStartDeviceError) {
         notifications.show({
-          message: `Unable to start ${deviceName}. Please select a different device.`,
+          message: `Unable to start ${deviceName}. Please select a different Capture Source.`,
         });
         device.current = undefined;
       }
@@ -96,8 +96,8 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
       );
 
       if (currentDevice && !currentDeviceConnected) {
-        rLogger.info("currentDeviceDisconnected", "The current device was disconnected");
-        notifications.show({ message: "Current device was disconnected." });
+        rLogger.info("currentDeviceDisconnected", "Current Capture Source was disconnected");
+        notifications.show({ message: "Current Capture Source was disconnected." });
         closeDevice();
       }
     };

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
@@ -19,8 +19,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
   const deviceList = useDeviceList();
 
   const [hasCameraAccess, setHasCameraAccess] = useState(false);
-  // todo rename to deviceLoading and swap around true and false
-  const [deviceReady, setDeviceReady] = useState(true);
+  const [deviceLoading, setDeviceLoading] = useState(false);
   const device = useRef<ImagingDevice | undefined>(undefined);
 
   const [deviceStatusKey, setDeviceStatusKey] = useState(uuidv4());
@@ -34,7 +33,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
   );
 
   const changeDevice = async (identifier: ImagingDeviceIdentifier) => {
-    setDeviceReady(false);
+    setDeviceLoading(true);
     device.current?.close();
     const newDevice = deviceIdentifierToDevice(identifier);
     device.current = newDevice;
@@ -42,19 +41,19 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
     try {
       await newDevice.open();
     } finally {
-      setDeviceReady(true);
+      setDeviceLoading(false);
       updateDeviceStatus();
     }
   };
 
   const changeResolution = async (resolution: ImagingDeviceResolution) => {
-    setDeviceReady(false);
+    setDeviceLoading(true);
     device.current?.close();
 
     try {
       await device.current?.open(resolution);
     } finally {
-      setDeviceReady(true);
+      setDeviceLoading(false);
       updateDeviceStatus();
     }
   };
@@ -100,7 +99,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
         deviceIdentifier,
         deviceStream,
         deviceResolution,
-        deviceReady,
+        deviceLoading,
         changeDevice,
         changeResolution,
         closeDevice,

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -16,12 +16,6 @@ interface ImagingDeviceCapabilities {
   changeResolution: boolean;
 }
 
-export interface ImagingDeviceStatus {
-  identifier: ImagingDeviceIdentifier;
-  open: boolean;
-  resolution: ImagingDeviceResolution | undefined;
-}
-
 export interface ImagingDevice {
   stream?: MediaStream;
   identifier: ImagingDeviceIdentifier;

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -16,6 +16,11 @@ interface ImagingDeviceCapabilities {
   changeResolution: boolean;
 }
 
+export interface ImagingDeviceStatus {
+  stream: MediaStream;
+  resolution: ImagingDeviceResolution;
+}
+
 export interface ImagingDevice {
   stream?: MediaStream;
   identifier: ImagingDeviceIdentifier;

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -1,4 +1,5 @@
 import * as rLogger from "../../services/rLogger/rLogger";
+import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
 import WebMediaDevice from "./WebMediaDevice";
 
 export enum ImagingDeviceType {
@@ -24,9 +25,10 @@ export interface ImagingDevice {
   stream?: MediaStream;
   identifier: ImagingDeviceIdentifier;
   capabilities: ImagingDeviceCapabilities;
-  open(): Promise<void>;
+  open(resolution?: ImagingDeviceResolution): Promise<void>;
   close(): void;
   captureImage(): Promise<Blob>;
+  getResolution(): ImagingDeviceResolution;
 }
 
 export const listDevices = async (): Promise<ImagingDeviceIdentifier[]> => {

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -19,6 +19,7 @@ interface ImagingDeviceCapabilities {
 export interface ImagingDeviceStatus {
   identifier: ImagingDeviceIdentifier;
   open: boolean;
+  resolution: ImagingDeviceResolution | undefined;
 }
 
 export interface ImagingDevice {

--- a/src/renderer/services/imagingDevice/ImagingDeviceErrors.ts
+++ b/src/renderer/services/imagingDevice/ImagingDeviceErrors.ts
@@ -1,0 +1,11 @@
+export class UnableToStartDeviceError extends Error {
+  constructor() {
+    super("Unable to use the selected device");
+  }
+}
+
+export class UnableToUseResolutionDeviceError extends Error {
+  constructor() {
+    super("Unable to use the selected resolution");
+  }
+}

--- a/src/renderer/services/imagingDevice/ImagingDeviceResolution.test.ts
+++ b/src/renderer/services/imagingDevice/ImagingDeviceResolution.test.ts
@@ -1,0 +1,26 @@
+import {
+  makeResolutionSelectData,
+  ResolutionName,
+  resolutionToName,
+} from "./ImagingDeviceResolution";
+
+describe("makeResolutionSelectData", () => {
+  it("should make expected makeResolutionSelectData", () => {
+    expect(makeResolutionSelectData()).toEqual(
+      expect.arrayContaining([
+        { value: ResolutionName.RES_1080P, label: "1920×1080" },
+        { value: ResolutionName.RES_CUSTOM, label: "Custom" },
+      ])
+    );
+  });
+});
+
+describe("resolutionToName", () => {
+  it("should make expected resolution name for named resolution", () => {
+    expect(resolutionToName({ width: 1920, height: 1080 })).toEqual(ResolutionName.RES_1080P);
+  });
+
+  it("should make expected resolution name for custom resolution", () => {
+    expect(resolutionToName({ width: 9999, height: 9999 })).toEqual(ResolutionName.RES_CUSTOM);
+  });
+});

--- a/src/renderer/services/imagingDevice/ImagingDeviceResolution.test.ts
+++ b/src/renderer/services/imagingDevice/ImagingDeviceResolution.test.ts
@@ -10,8 +10,8 @@ describe("makeResolutionSelectData", () => {
   it("should make expected makeResolutionSelectData", () => {
     expect(makeResolutionSelectData()).toEqual(
       expect.arrayContaining([
-        { value: ResolutionName.RES_1080P, label: "1920×1080" },
-        { value: ResolutionName.RES_CUSTOM, label: "Custom" },
+        { value: ResolutionName.RES_1080P, label: "1920×1080 (1080p FHD)" },
+        { value: ResolutionName.RES_CUSTOM, label: "Custom..." },
       ])
     );
   });

--- a/src/renderer/services/imagingDevice/ImagingDeviceResolution.test.ts
+++ b/src/renderer/services/imagingDevice/ImagingDeviceResolution.test.ts
@@ -1,5 +1,7 @@
 import {
+  areResolutionsEqual,
   makeResolutionSelectData,
+  NAME_TO_RESOLUTION,
   ResolutionName,
   resolutionToName,
 } from "./ImagingDeviceResolution";
@@ -22,5 +24,46 @@ describe("resolutionToName", () => {
 
   it("should make expected resolution name for custom resolution", () => {
     expect(resolutionToName({ width: 9999, height: 9999 })).toEqual(ResolutionName.RES_CUSTOM);
+  });
+});
+
+describe("areResolutionsEqual", () => {
+  it("should return true for 2 equal resolutions", () => {
+    expect(areResolutionsEqual(undefined, undefined)).toBe(true);
+    expect(
+      areResolutionsEqual(
+        NAME_TO_RESOLUTION[ResolutionName.RES_1080P],
+        NAME_TO_RESOLUTION[ResolutionName.RES_1080P]
+      )
+    ).toBe(true);
+    expect(areResolutionsEqual({ width: 1280, height: 720 }, { width: 1280, height: 720 })).toBe(
+      true
+    );
+    expect(areResolutionsEqual({ width: 0, height: 720 }, { width: 0, height: 720 })).toBe(true);
+    expect(areResolutionsEqual({ width: 1280, height: 0 }, { width: 1280, height: 0 })).toBe(true);
+    expect(areResolutionsEqual(NAME_TO_RESOLUTION[ResolutionName.RES_CUSTOM], undefined)).toBe(
+      true
+    );
+  });
+
+  it("should return false for 2 different resolutions", () => {
+    expect(
+      areResolutionsEqual(
+        NAME_TO_RESOLUTION[ResolutionName.RES_1080P],
+        NAME_TO_RESOLUTION[ResolutionName.RES_720P]
+      )
+    ).toBe(false);
+    expect(areResolutionsEqual({ width: 1280, height: 720 }, { width: 1281, height: 720 })).toBe(
+      false
+    );
+    expect(areResolutionsEqual({ width: 1280, height: 720 }, { width: 1280, height: 721 })).toBe(
+      false
+    );
+    expect(areResolutionsEqual(NAME_TO_RESOLUTION[ResolutionName.RES_1080P], undefined)).toBe(
+      false
+    );
+    expect(areResolutionsEqual(undefined, NAME_TO_RESOLUTION[ResolutionName.RES_1080P])).toBe(
+      false
+    );
   });
 });

--- a/src/renderer/services/imagingDevice/ImagingDeviceResolution.ts
+++ b/src/renderer/services/imagingDevice/ImagingDeviceResolution.ts
@@ -5,29 +5,53 @@ export interface ImagingDeviceResolution {
   height: number;
 }
 
+interface ImagingDeviceResolutionInfo extends ImagingDeviceResolution {
+  label: string;
+}
+
 export enum ResolutionName {
+  RES_4K = "RES_4K",
+  RES_2K = "RES_2K",
   RES_1080P = "RES_1080P",
   RES_720P = "RES_720P",
+  RES_480P = "RES_480P",
   RES_CUSTOM = "RES_CUSTOM",
 }
 
-export const NAME_TO_RESOLUTION: Partial<Record<ResolutionName, ImagingDeviceResolution>> = {
+export const NAME_TO_RESOLUTION: Partial<Record<ResolutionName, ImagingDeviceResolutionInfo>> = {
+  [ResolutionName.RES_4K]: {
+    label: "2160p 4K",
+    width: 3840,
+    height: 2160,
+  },
+  [ResolutionName.RES_2K]: {
+    label: "1440p 2K",
+    width: 2560,
+    height: 1440,
+  },
   [ResolutionName.RES_1080P]: {
+    label: "1080p FHD",
     width: 1920,
     height: 1080,
   },
   [ResolutionName.RES_720P]: {
+    label: "720p HD",
     width: 1280,
     height: 720,
+  },
+  [ResolutionName.RES_480P]: {
+    label: "480p SD",
+    width: 854,
+    height: 480,
   },
 };
 
 export const makeResolutionSelectData = (): ComboboxData => {
   const options = Object.entries(NAME_TO_RESOLUTION).map(([name, resolution]) => ({
     value: name as ResolutionName,
-    label: `${resolution.width}×${resolution.height}`,
+    label: `${resolution.width}×${resolution.height} (${resolution.label})`,
   }));
-  const customOption = { value: ResolutionName.RES_CUSTOM, label: "Custom" };
+  const customOption = { value: ResolutionName.RES_CUSTOM, label: "Custom..." };
   return [...options, customOption];
 };
 

--- a/src/renderer/services/imagingDevice/ImagingDeviceResolution.ts
+++ b/src/renderer/services/imagingDevice/ImagingDeviceResolution.ts
@@ -32,9 +32,14 @@ export const makeResolutionSelectData = (): ComboboxData => {
 };
 
 export const resolutionToName = (curResolution: ImagingDeviceResolution): ResolutionName => {
-  const option = Object.entries(NAME_TO_RESOLUTION).find(
-    ([, resolution]) =>
-      resolution.width === curResolution.width && resolution.height === curResolution.height
+  const option = Object.entries(NAME_TO_RESOLUTION).find(([, resolution]) =>
+    areResolutionsEqual(resolution, curResolution)
   );
   return option ? (option[0] as ResolutionName) : ResolutionName.RES_CUSTOM;
 };
+
+export const areResolutionsEqual = (
+  resolution1?: ImagingDeviceResolution,
+  resolution2?: ImagingDeviceResolution
+): boolean =>
+  resolution1?.width === resolution2?.width && resolution1?.height === resolution2?.height;

--- a/src/renderer/services/imagingDevice/ImagingDeviceResolution.ts
+++ b/src/renderer/services/imagingDevice/ImagingDeviceResolution.ts
@@ -1,0 +1,40 @@
+import { ComboboxData } from "@mantine/core";
+
+export interface ImagingDeviceResolution {
+  width: number;
+  height: number;
+}
+
+export enum ResolutionName {
+  RES_1080P = "RES_1080P",
+  RES_720P = "RES_720P",
+  RES_CUSTOM = "RES_CUSTOM",
+}
+
+export const NAME_TO_RESOLUTION: Partial<Record<ResolutionName, ImagingDeviceResolution>> = {
+  [ResolutionName.RES_1080P]: {
+    width: 1920,
+    height: 1080,
+  },
+  [ResolutionName.RES_720P]: {
+    width: 1280,
+    height: 720,
+  },
+};
+
+export const makeResolutionSelectData = (): ComboboxData => {
+  const options = Object.entries(NAME_TO_RESOLUTION).map(([name, resolution]) => ({
+    value: name as ResolutionName,
+    label: `${resolution.width}×${resolution.height}`,
+  }));
+  const customOption = { value: ResolutionName.RES_CUSTOM, label: "Custom" };
+  return [...options, customOption];
+};
+
+export const resolutionToName = (curResolution: ImagingDeviceResolution): ResolutionName => {
+  const option = Object.entries(NAME_TO_RESOLUTION).find(
+    ([, resolution]) =>
+      resolution.width === curResolution.width && resolution.height === curResolution.height
+  );
+  return option ? (option[0] as ResolutionName) : ResolutionName.RES_CUSTOM;
+};

--- a/src/renderer/services/imagingDevice/WebMediaDevice.ts
+++ b/src/renderer/services/imagingDevice/WebMediaDevice.ts
@@ -1,6 +1,7 @@
 import { notifications } from "@mantine/notifications";
 import * as rLogger from "../rLogger/rLogger";
 import { ImagingDevice, ImagingDeviceIdentifier, ImagingDeviceType } from "./ImagingDevice";
+import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
 
 const EXTREMELY_LARGE_WIDTH = 99999;
 
@@ -12,14 +13,19 @@ class WebMediaDevice implements ImagingDevice {
 
   constructor(public identifier: ImagingDeviceIdentifier) {}
 
-  async open(): Promise<void> {
+  async open(resolution?: ImagingDeviceResolution): Promise<void> {
     rLogger.info("webMediaDevice.open.start");
+
+    const resolutionConstraints: MediaTrackConstraints = resolution
+      ? { width: { exact: resolution.width }, height: { exact: resolution.height } }
+      : { width: { ideal: EXTREMELY_LARGE_WIDTH } };
+
     try {
       this.stream = await navigator.mediaDevices.getUserMedia({
         audio: false,
         video: {
           deviceId: { exact: this.identifier.deviceId },
-          width: { ideal: EXTREMELY_LARGE_WIDTH },
+          ...resolutionConstraints,
         },
       });
 
@@ -104,6 +110,7 @@ class WebMediaDevice implements ImagingDevice {
     try {
       const videoTrack = this.stream.getVideoTracks()[0];
       const { width: videoWidth, height: videoHeight } = videoTrack.getSettings();
+      rLogger.info("takePhotoDimensions", { videoWidth, videoHeight });
       return this.imageCapture.takePhoto({
         imageWidth: videoWidth,
         imageHeight: videoHeight,
@@ -136,6 +143,19 @@ class WebMediaDevice implements ImagingDevice {
       throw "Unable to grabFrame as toBlob returned null";
     }
     return image;
+  }
+
+  getResolution(): ImagingDeviceResolution {
+    if (this.stream === undefined) {
+      throw "Device must be open before getResolution can be called";
+    }
+
+    const { width, height } = this.stream.getVideoTracks()[0].getSettings();
+    if (width === undefined || height === undefined) {
+      throw "Unable to device getResolution";
+    }
+
+    return { width, height };
   }
 
   static async listDevices(): Promise<ImagingDeviceIdentifier[]> {

--- a/src/renderer/services/imagingDevice/WebMediaDevice.ts
+++ b/src/renderer/services/imagingDevice/WebMediaDevice.ts
@@ -1,7 +1,7 @@
-import { notifications } from "@mantine/notifications";
 import * as rLogger from "../rLogger/rLogger";
 import { ImagingDevice, ImagingDeviceIdentifier, ImagingDeviceType } from "./ImagingDevice";
 import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
+import { UnableToStartDeviceError, UnableToUseResolutionDeviceError } from "./ImagingDeviceErrors";
 
 const EXTREMELY_LARGE_WIDTH = 99999;
 
@@ -38,8 +38,12 @@ class WebMediaDevice implements ImagingDevice {
     } catch (e) {
       rLogger.info("webMediaDevice.open.deviceError", `${e}`);
       this.close();
-      // todo throw error and handle outside of this file
-      notifications.show({ message: `Unable to start ${this.identifier.name}` });
+
+      if (e instanceof OverconstrainedError) {
+        throw new UnableToUseResolutionDeviceError();
+      }
+
+      throw new UnableToStartDeviceError();
     }
   }
 
@@ -169,7 +173,7 @@ class WebMediaDevice implements ImagingDevice {
       .filter((device) => device.kind === "videoinput")
       .map((device) => ({
         deviceId: device.deviceId,
-        name: device.label.split("(")[0],
+        name: device.label.split("(")[0].trim(),
         type: ImagingDeviceType.WEB_MEDIA,
       }));
   }

--- a/src/renderer/services/imagingDevice/WebMediaDevice.ts
+++ b/src/renderer/services/imagingDevice/WebMediaDevice.ts
@@ -15,6 +15,9 @@ class WebMediaDevice implements ImagingDevice {
 
   async open(resolution?: ImagingDeviceResolution): Promise<void> {
     rLogger.info("webMediaDevice.open.start");
+    if (this.stream) {
+      throw "Device is already open";
+    }
 
     const resolutionConstraints: MediaTrackConstraints = resolution
       ? { width: { exact: resolution.width }, height: { exact: resolution.height } }

--- a/src/renderer/services/imagingDevice/WebMediaDevice.ts
+++ b/src/renderer/services/imagingDevice/WebMediaDevice.ts
@@ -38,6 +38,7 @@ class WebMediaDevice implements ImagingDevice {
     } catch (e) {
       rLogger.info("webMediaDevice.open.deviceError", `${e}`);
       this.close();
+      // todo throw error and handle outside of this file
       notifications.show({ message: `Unable to start ${this.identifier.name}` });
     }
   }


### PR DESCRIPTION
Reimplements change resolution and refactors the ImagingDeviceContextProvider to be way nicer. It was a bit overcomplicated before because you had to update the deviceState which triggered a useEffect in order to change device.