### PR TITLE
Add test camera

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,10 +30,6 @@
     "react/react-in-jsx-scope": "off",
     "react/display-name": "off",
     "react/prop-types": "off",
-    "@typescript-eslint/strict-boolean-expressions": [
-      "error",
-      { "allowString": false, "allowNumber": false }
-    ],
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-member-accessibility": "off",

--- a/src/common/UserPreferences.ts
+++ b/src/common/UserPreferences.ts
@@ -2,10 +2,12 @@ export interface UserPreferences {
   playCaptureSound: boolean;
   shortPlayLength: number;
   showTimestampInSeconds: boolean;
+  showTestCamera: boolean;
 }
 
 export const defaultUserPreferences: UserPreferences = {
   playCaptureSound: true,
   shortPlayLength: 6,
   showTimestampInSeconds: false,
+  showTestCamera: false,
 };

--- a/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
+++ b/src/renderer/components/modals/CaptureSourceModal/CaptureSourceModal.tsx
@@ -31,7 +31,7 @@ export const CaptureSourceModal = () => {
   }));
 
   const resolution = deviceStatus?.resolution;
-  const resolutionName = resolution ? resolutionToName(resolution) : undefined;
+  const resolutionName = resolution !== undefined ? resolutionToName(resolution) : undefined;
   const [showCustomResolution, setShowCustomResolution] = useState(false);
 
   const handleChangeDevice = async (newDeviceId: string | undefined) => {

--- a/src/renderer/components/modals/PreferencesModal/PreferencesModal.tsx
+++ b/src/renderer/components/modals/PreferencesModal/PreferencesModal.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "@mantine/core";
+import { Stack, Title } from "@mantine/core";
 import { useDispatch, useSelector } from "react-redux";
 import { PageRoute } from "../../../../common/PageRoute";
 import { editUserPreferences } from "../../../redux/slices/appSlice";
@@ -21,9 +21,8 @@ const PreferencesModal = (): JSX.Element => {
 
   return (
     <UiModal title="Preferences" onClose={take ? PageRoute.ANIMATOR : PageRoute.STARTUP}>
-      <h3>Interface</h3>
-
       <Stack>
+        <Title order={4}>Interface</Title>
         <UiSwitch
           label="Play capture sound"
           checked={userPreferences.playCaptureSound}
@@ -35,7 +34,6 @@ const PreferencesModal = (): JSX.Element => {
             )
           }
         />
-
         <UiSwitch
           label="Initially show timestamp in seconds rather than frames"
           checked={userPreferences.showTimestampInSeconds}
@@ -47,24 +45,36 @@ const PreferencesModal = (): JSX.Element => {
             )
           }
         />
+
+        <Title order={4}>Playback</Title>
+        <UiNumberInput
+          label="Short play length"
+          value={userPreferences.shortPlayLength}
+          placeholder="6"
+          min={1}
+          max={99}
+          onChange={(newValue) =>
+            dispatch(
+              editUserPreferences({
+                shortPlayLength: newValue,
+              })
+            )
+          }
+        />
+
+        <Title order={4}>Developer</Title>
+        <UiSwitch
+          label="Show test camera in Capture Sources"
+          checked={userPreferences.showTestCamera}
+          onChange={() =>
+            dispatch(
+              editUserPreferences({
+                showTestCamera: !userPreferences.showTestCamera,
+              })
+            )
+          }
+        />
       </Stack>
-
-      <h3>Playback</h3>
-
-      <UiNumberInput
-        label="Short play length"
-        value={userPreferences.shortPlayLength}
-        placeholder="6"
-        min={1}
-        max={99}
-        onChange={(newValue) =>
-          dispatch(
-            editUserPreferences({
-              shortPlayLength: newValue,
-            })
-          )
-        }
-      />
 
       <UiModalFooter>
         <UiButton icon={IconName.FOLDER} onClick={window.preload.ipcToMain.openUserDataDirectory}>

--- a/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
+++ b/src/renderer/context/ImagingDeviceContext/ImagingDeviceContextProvider.tsx
@@ -60,6 +60,7 @@ export const ImagingDeviceContextProvider = ({ children }: ImagingDeviceContextP
 
     try {
       await device.current?.open(resolution);
+      // console.log("cr", deviceName, resolution);
     } catch {
       notifications.show({
         message: `Resolution not supported by ${deviceName}. Please select a different resolution.`,

--- a/src/renderer/hooks/useDeviceList.ts
+++ b/src/renderer/hooks/useDeviceList.ts
@@ -5,22 +5,26 @@ import {
   listDevices,
   removeDeviceChangeListeners,
 } from "../services/imagingDevice/ImagingDevice";
+import { useSelector } from "react-redux";
+import { RootState } from "../redux/store";
 
 const useDeviceList = () => {
+  const showTestCamera = useSelector(
+    (state: RootState) => state.app.userPreferences.showTestCamera
+  );
   const [deviceList, setDeviceList] = useState<ImagingDeviceIdentifier[]>([]);
 
-  const fetchDeviceList = async () => {
-    setDeviceList(await listDevices());
-  };
-
   useEffect(() => {
+    const fetchDeviceList = async () => {
+      setDeviceList(await listDevices(showTestCamera));
+    };
     fetchDeviceList();
     addDeviceChangeListeners(fetchDeviceList);
 
     return () => {
       removeDeviceChangeListeners(fetchDeviceList);
     };
-  }, []);
+  }, [showTestCamera]);
 
   return deviceList;
 };

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -1,9 +1,9 @@
 import * as rLogger from "../../services/rLogger/rLogger";
 import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
-import { makeTestCameraIdentifier, TestCamera } from "./TestCamera";
+import { TEST_CAMERA_IDENTIFIER, TestCamera } from "./TestCamera";
 import WebMediaDevice from "./WebMediaDevice";
 
-export enum ImagingDeviceType {
+export const enum ImagingDeviceType {
   TEST_CAMERA = "TEST_CAMERA",
   WEB_MEDIA = "WEB_MEDIA",
 }
@@ -35,7 +35,7 @@ export interface ImagingDevice {
 
 export const listDevices = async (showTestDevice: boolean): Promise<ImagingDeviceIdentifier[]> => {
   rLogger.info("imagingDevice.listDevices.start");
-  const testDevices = showTestDevice ? [makeTestCameraIdentifier()] : [];
+  const testDevices = showTestDevice ? [TEST_CAMERA_IDENTIFIER] : [];
   const webMediaDevices = [...(await WebMediaDevice.listDevices())];
   const allDevices = [...testDevices, ...webMediaDevices];
   rLogger.info("imagingDevice.listDevices.end", `${allDevices.length} device(s) found`);

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -36,7 +36,7 @@ export interface ImagingDevice {
 export const listDevices = async (showTestDevice: boolean): Promise<ImagingDeviceIdentifier[]> => {
   rLogger.info("imagingDevice.listDevices.start");
   const testDevices = showTestDevice ? [TEST_CAMERA_IDENTIFIER] : [];
-  const webMediaDevices = [...(await WebMediaDevice.listDevices())];
+  const webMediaDevices = await WebMediaDevice.listDevices();
   const allDevices = [...testDevices, ...webMediaDevices];
   rLogger.info("imagingDevice.listDevices.end", `${allDevices.length} device(s) found`);
 

--- a/src/renderer/services/imagingDevice/ImagingDevice.ts
+++ b/src/renderer/services/imagingDevice/ImagingDevice.ts
@@ -1,8 +1,10 @@
 import * as rLogger from "../../services/rLogger/rLogger";
 import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
+import { makeTestCameraIdentifier, TestCamera } from "./TestCamera";
 import WebMediaDevice from "./WebMediaDevice";
 
 export enum ImagingDeviceType {
+  TEST_CAMERA = "TEST_CAMERA",
   WEB_MEDIA = "WEB_MEDIA",
 }
 
@@ -31,10 +33,11 @@ export interface ImagingDevice {
   getResolution(): ImagingDeviceResolution;
 }
 
-export const listDevices = async (): Promise<ImagingDeviceIdentifier[]> => {
+export const listDevices = async (showTestDevice: boolean): Promise<ImagingDeviceIdentifier[]> => {
   rLogger.info("imagingDevice.listDevices.start");
-  const webMediaDevices = await WebMediaDevice.listDevices();
-  const allDevices = [...webMediaDevices];
+  const testDevices = showTestDevice ? [makeTestCameraIdentifier()] : [];
+  const webMediaDevices = [...(await WebMediaDevice.listDevices())];
+  const allDevices = [...testDevices, ...webMediaDevices];
   rLogger.info("imagingDevice.listDevices.end", `${allDevices.length} device(s) found`);
 
   return allDevices;
@@ -52,5 +55,7 @@ export const deviceIdentifierToDevice = (identifier: ImagingDeviceIdentifier): I
   switch (identifier.type) {
     case ImagingDeviceType.WEB_MEDIA:
       return new WebMediaDevice(identifier);
+    case ImagingDeviceType.TEST_CAMERA:
+      return new TestCamera(identifier);
   }
 };

--- a/src/renderer/services/imagingDevice/TestCamera.ts
+++ b/src/renderer/services/imagingDevice/TestCamera.ts
@@ -1,0 +1,80 @@
+import { ImagingDevice, ImagingDeviceIdentifier, ImagingDeviceType } from "./ImagingDevice";
+import * as rLogger from "../rLogger/rLogger";
+import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
+import { v4 as uuidv4 } from "uuid";
+import { zeroPad } from "../../../common/utils";
+
+export class TestCamera implements ImagingDevice {
+  private canvas = document.createElement("canvas");
+  private textCounter = 0;
+  public stream?: MediaStream;
+  public capabilities = { changeResolution: true };
+
+  constructor(public identifier: ImagingDeviceIdentifier) {}
+
+  // todo handle resolutions
+  // todo why is kindof broken when you change res
+  async open(): Promise<void> {
+    rLogger.info("openTestDevice");
+    if (this.stream) {
+      throw "Device is already open";
+    }
+
+    this.canvas.height = 1080;
+    this.canvas.width = 1920;
+    this.addTextToCanvas("Live");
+
+    this.stream = this.canvas.captureStream();
+  }
+
+  close(): void {
+    rLogger.info("closeTestDevice");
+    this.stream?.getTracks().forEach((track) => track.stop());
+    this.stream = undefined;
+  }
+
+  async captureImage(): Promise<Blob> {
+    if (this.stream === undefined) {
+      throw "Device must be opened before captureImage can be called";
+    }
+
+    this.addTextToCanvas(zeroPad(this.textCounter++, 5));
+    const image: Blob | null = await new Promise((res) =>
+      this.canvas.toBlob((blob) => res(blob), "image/jpeg")
+    );
+    this.addTextToCanvas("Live");
+
+    if (image === null) {
+      throw "Unable to capture image as toBlob returned null";
+    }
+    return image;
+  }
+
+  getResolution(): ImagingDeviceResolution {
+    return { width: this.canvas.width, height: this.canvas.height };
+  }
+
+  private fillCanvasGreen() {
+    const context = this.canvas.getContext("2d");
+    if (context) {
+      context.fillStyle = "limegreen";
+      context.fillRect(0, 0, this.canvas.width, this.canvas.height);
+    }
+  }
+
+  private addTextToCanvas(text: string) {
+    const context = this.canvas.getContext("2d");
+    if (context) {
+      this.fillCanvasGreen();
+      context.font = "200px serif";
+      context.fillStyle = "black";
+      context.fillText(text, 300, 400);
+    }
+  }
+}
+
+export const makeTestCameraIdentifier = (): ImagingDeviceIdentifier => ({
+  type: ImagingDeviceType.TEST_CAMERA,
+  deviceId: uuidv4(),
+  name: "Test Camera",
+});

--- a/src/renderer/services/imagingDevice/TestCamera.ts
+++ b/src/renderer/services/imagingDevice/TestCamera.ts
@@ -1,8 +1,14 @@
-import { ImagingDevice, ImagingDeviceIdentifier, ImagingDeviceType } from "./ImagingDevice";
-import * as rLogger from "../rLogger/rLogger";
-import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
-import { v4 as uuidv4 } from "uuid";
 import { zeroPad } from "../../../common/utils";
+import * as rLogger from "../rLogger/rLogger";
+import { ImagingDevice, ImagingDeviceIdentifier, ImagingDeviceType } from "./ImagingDevice";
+import { ImagingDeviceResolution } from "./ImagingDeviceResolution";
+
+const TEST_CAMERA_DEVICE_ID = "a9cafa41-f712-478d-b23e-296e2cbf4ebe";
+export const TEST_CAMERA_IDENTIFIER: ImagingDeviceIdentifier = {
+  type: ImagingDeviceType.TEST_CAMERA,
+  deviceId: TEST_CAMERA_DEVICE_ID,
+  name: "Test Camera",
+};
 
 export class TestCamera implements ImagingDevice {
   private canvas = document.createElement("canvas");
@@ -14,14 +20,14 @@ export class TestCamera implements ImagingDevice {
 
   // todo handle resolutions
   // todo why is kindof broken when you change res
-  async open(): Promise<void> {
+  async open(resolution?: ImagingDeviceResolution): Promise<void> {
     rLogger.info("openTestDevice");
     if (this.stream) {
       throw "Device is already open";
     }
 
-    this.canvas.height = 1080;
-    this.canvas.width = 1920;
+    this.canvas.height = resolution?.height ?? 1080;
+    this.canvas.width = resolution?.width ?? 1920;
     this.addTextToCanvas("Live");
 
     this.stream = this.canvas.captureStream();
@@ -72,9 +78,3 @@ export class TestCamera implements ImagingDevice {
     }
   }
 }
-
-export const makeTestCameraIdentifier = (): ImagingDeviceIdentifier => ({
-  type: ImagingDeviceType.TEST_CAMERA,
-  deviceId: uuidv4(),
-  name: "Test Camera",
-});

--- a/src/renderer/services/imagingDevice/TestCamera.ts
+++ b/src/renderer/services/imagingDevice/TestCamera.ts
@@ -18,8 +18,6 @@ export class TestCamera implements ImagingDevice {
 
   constructor(public identifier: ImagingDeviceIdentifier) {}
 
-  // todo handle resolutions
-  // todo why is kindof broken when you change res
   async open(resolution?: ImagingDeviceResolution): Promise<void> {
     rLogger.info("openTestDevice");
     if (this.stream) {


### PR DESCRIPTION
Adds a test camera to the Capture Sources when an option is enabled in settings. This will make it easier to test without always requiring to have a real camera. Also handy for testing stuff that only works on some OSs (eg camera settings).

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/806dc5e3-7650-4f8a-b33c-7c62b26a0300">
